### PR TITLE
build(deps): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Consider enabling this :

![image](https://user-images.githubusercontent.com/8935151/157544867-ff6323b0-9060-43c9-b389-442acdce3ce1.png)
