### PR TITLE
feat: add spring-boot-starter-validation to enable model validations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,11 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-validation</artifactId>
+                <version>${spring-boot-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-webflux</artifactId>
                 <version>${spring-boot-framework.version}</version>
                 <exclusions>


### PR DESCRIPTION
Add spring-boot-starter-validation so that services can make use of the field validations on request models