### PR TITLE
Removing Primary annotation from Synapse's default object mapper

### DIFF
--- a/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/config/UtilitiesCommonConfig.java
+++ b/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/config/UtilitiesCommonConfig.java
@@ -116,7 +116,6 @@ public class UtilitiesCommonConfig {
      * @return the default object mapper
      */
     @Bean(SYNAPSE_OBJECT_MAPPER)
-    @Primary
     public ObjectMapper defaultObjectMapper() {
         final ObjectMapper mapper = getInitialObjectMapper();
         mapper.setSerializationInclusion(Include.NON_EMPTY);


### PR DESCRIPTION
Erased `@Primary` from the default object mapper, so that users are not forced to use Synapse's default object mapper. Users will be able to implement their own @Primary object mapper bean and or re-use Synapse's object mappers.