### PR TITLE
New Version without @Primary object mapper.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,22 +117,22 @@ workflows:
           requires:
             - build-test-job
 
-  # Release Branch
-  # This workflow is to start automatically when creating any new release branches and when pushing any changes to release branches
-  snapshot-release-maven-central-build-test-deploy-workflow:
-    jobs:
-      - build-test-job:
-          filters:
-            branches:
-              only:
-                - /release.*/
-      - snapshot-release-maven-central-deploy-job:
-          filters:
-            branches:
-              only:
-                - /release.*/
-          context:
-            - maven_central_credentials
-            - code_signing_credentials
-          requires:
-            - build-test-job
+#  # Release Branch
+#  # This workflow is to start automatically when creating any new release branches and when pushing any changes to release branches
+#  snapshot-release-maven-central-build-test-deploy-workflow:
+#    jobs:
+#      - build-test-job:
+#          filters:
+#            branches:
+#              only:
+#                - /release.*/
+#      - snapshot-release-maven-central-deploy-job:
+#          filters:
+#            branches:
+#              only:
+#                - /release.*/
+#          context:
+#            - maven_central_credentials
+#            - code_signing_credentials
+#          requires:
+#            - build-test-job

--- a/archetype/archetype-catalog.xml
+++ b/archetype/archetype-catalog.xml
@@ -20,56 +20,56 @@
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-graphql</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-delete</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-get</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-post</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-put</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-reactive</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-reactive-get</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 		<archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-reactive-post</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype><archetype>
 			<groupId>io.americanexpress.synapse</groupId>
 			<artifactId>synapse-archetype-client-rest-reactive-put</artifactId>
-			<version>0.2.3-SNAPSHOT</version>
+			<version>0.2.4-SNAPSHOT</version>
 		</archetype>
 	</archetypes>
 </archetype-catalog>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-graphql</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-delete</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-put</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.2.3-SNAPSHOT</synapse.version>
+		<synapse.version>0.2.4-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/example-data-postgres-book/pom.xml
+++ b/data/example-data-postgres-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.americanexpress.synapse</groupId>
     <artifactId>synapse</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.3-SNAPSHOT</version>
+    <version>0.2.4-SNAPSHOT</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise
@@ -644,13 +644,6 @@
                 <groupId>com.couchbase.client</groupId>
                 <artifactId>java-client</artifactId>
                 <version>3.1.4</version>
-            </dependency>
-
-            <!--Lombok-->
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>1.18.24</version>
             </dependency>
 
             <!--Quarkus-->

--- a/pom.xml
+++ b/pom.xml
@@ -845,7 +845,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>2.3.1</version>
+                    <version>3.1.0</version>
                     <executions>
                         <execution>
                             <phase>generate-sources</phase>

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/example-service-graphql-book/pom.xml
+++ b/service/example-service-graphql-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/example-service-rest-book/pom.xml
+++ b/service/example-service-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.2.3-SNAPSHOT</version>
+        <version>0.2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/config/UtilitiesCommonConfig.java
+++ b/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/config/UtilitiesCommonConfig.java
@@ -116,7 +116,6 @@ public class UtilitiesCommonConfig {
      * @return the default object mapper
      */
     @Bean(SYNAPSE_OBJECT_MAPPER)
-    @Primary
     public ObjectMapper defaultObjectMapper() {
         final ObjectMapper mapper = getInitialObjectMapper();
         mapper.setSerializationInclusion(Include.NON_EMPTY);


### PR DESCRIPTION
In this merge, we are deleting `@Primary` from `SYNAPSE_OBJECT_MAPPER` so that if the user wants to create his own Primary object, he won't have conflicts.