### PR TITLE
fix(): fixing unit test

### DIFF
--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseRestClientUnitTest.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseRestClientUnitTest.java
@@ -20,7 +20,6 @@ import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
 import io.americanexpress.synapse.client.rest.model.ClientHeaders;
 import io.americanexpress.synapse.client.rest.model.QueryParameter;
 import io.americanexpress.synapse.framework.exception.ApplicationClientException;
-import io.americanexpress.synapse.framework.exception.ApplicationServerException;
 import io.americanexpress.synapse.framework.exception.model.ErrorCode;
 import io.americanexpress.synapse.framework.test.CommonAssertionMessages;
 
@@ -156,7 +155,7 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
     @Test
     void callMonoService_givenServerError_expectedApplicationClientException() throws IOException {
         responseActions.andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(clientResponse)));
-        Assertions.assertThrows(ApplicationServerException.class, this::callMonoServiceAndAssertErrorResponse, CommonAssertionMessages.EXCEPTION_NOT_THROWN);
+        Assertions.assertThrows(ApplicationClientException.class, this::callMonoServiceAndAssertErrorResponse, CommonAssertionMessages.EXCEPTION_NOT_THROWN);
     }
     
     private MockRestServiceServer getMockServer() {


### PR DESCRIPTION
Fixing the callMonoService_givenServerError_expectedApplicationClientException to throw the ApplicationClientException instead of ApplicationServerException