### PR TITLE
feat(client-test): adding base IT tests for reactive clients

### DIFF
--- a/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientIT.java
+++ b/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientIT.java
@@ -14,37 +14,40 @@
 package io.americanexpress.sample.client.reactive.weather.client;
 
 import io.americanexpress.sample.client.reactive.weather.config.WeatherReactiveClientTestConfig;
+import io.americanexpress.sample.client.reactive.weather.model.WeatherRequest;
 import io.americanexpress.sample.client.reactive.weather.model.WeatherResponse;
-import io.americanexpress.synapse.framework.test.CommonAssertionMessages;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import io.americanexpress.synapse.client.test.client.BaseGetReactiveRestClientIT;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import reactor.core.publisher.Mono;
 
 /**
  * {@code WeatherReactiveClientIT} tests the {@link WeatherReactiveClient}.
  */
 @ContextConfiguration(classes = WeatherReactiveClientTestConfig.class)
 @ExtendWith(SpringExtension.class)
-class WeatherReactiveClientIT {
+class WeatherReactiveClientIT extends BaseGetReactiveRestClientIT<WeatherRequest, WeatherResponse, WeatherReactiveClient> {
+    @Override
+    protected String mockPathVariables() {
+        return null;
+    }
 
-    /**
-     * Weather client
-     */
-    @Autowired
-    private WeatherReactiveClient client;
-
-    @Test
-    void callMonoService_givenValidRequest_expectedSuccessResponse() {
+    @Override
+    protected HttpHeaders getDefaultClientHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
 
-        Mono<WeatherResponse> response = client.callMonoService(headers, null);
-        Assertions.assertNotNull(response.block(), CommonAssertionMessages.RESPONSE_IS_NULL);
+    @Override
+    protected WeatherRequest mockDefaultClientRequest() {
+        return null;
+    }
+
+    @Override
+    protected WeatherRequest mockInvalidClientRequest() {
+        return null;
     }
 }

--- a/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientTest.java
+++ b/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.americanexpress.sample.client.reactive.weather.client;
 
 import io.americanexpress.sample.client.reactive.weather.config.WeatherReactiveClientTestConfig;

--- a/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientTest.java
+++ b/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/client/WeatherReactiveClientTest.java
@@ -1,0 +1,35 @@
+package io.americanexpress.sample.client.reactive.weather.client;
+
+import io.americanexpress.sample.client.reactive.weather.config.WeatherReactiveClientTestConfig;
+import io.americanexpress.sample.client.reactive.weather.model.WeatherRequest;
+import io.americanexpress.sample.client.reactive.weather.model.WeatherResponse;
+import io.americanexpress.synapse.client.test.client.BaseReactiveRestClientUnitTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * {@code WeatherReactiveClientTest} tests the {@link WeatherReactiveClient}.
+ */
+@ContextConfiguration(classes = WeatherReactiveClientTestConfig.class)
+public class WeatherReactiveClientTest extends BaseReactiveRestClientUnitTest<WeatherRequest, WeatherResponse, WeatherReactiveClient> {
+
+    @Override
+    public WeatherRequest mockDefaultClientRequest() {
+        return null;
+    }
+
+    @Override
+    public WeatherResponse mockDefaultClientResponse() {
+        return new WeatherResponse();
+    }
+
+    @Override
+    public HttpHeaders mockClientHeaders() {
+        return new HttpHeaders();
+    }
+
+    @Override
+    public String mockPathVariables() {
+        return null;
+    }
+}

--- a/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/config/WeatherReactiveClientTestConfig.java
+++ b/client/client-samples/sample-client-reactive-weather/src/test/java/io/americanexpress/sample/client/reactive/weather/config/WeatherReactiveClientTestConfig.java
@@ -13,6 +13,7 @@
  */
 package io.americanexpress.sample.client.reactive.weather.config;
 
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -20,6 +21,6 @@ import org.springframework.context.annotation.Import;
  * {@code WeatherReactiveClientTestConfig} contains configurations for tests.
  */
 @Configuration
-@Import(WeatherReactiveClientConfig.class)
+@Import({WeatherReactiveClientConfig.class, UtilitiesCommonConfig.class})
 public class WeatherReactiveClientTestConfig {
 }

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -29,6 +29,11 @@
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>synapse-client-rest</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseDeleteReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseDeleteReactiveRestClientIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.client.test.client;
+
+import io.americanexpress.synapse.client.rest.client.BaseDeleteReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@code BaseDeleteReactiveRestClientIT} is the extensible class for IT testing DELETE reactive rest clients.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ * @param <C> the reactive client type
+ */
+@ExtendWith(SpringExtension.class)
+public abstract class BaseDeleteReactiveRestClientIT<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BaseDeleteReactiveRestClient<I, O>> extends BaseReactiveRestClientIT<I, O, C> {
+
+
+    /**
+     * Call mono service given valid request expected success response.
+     */
+    @Test
+    void callMonoService_givenValidRequest_expectedSuccessResponse() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockDefaultClientRequest());
+        StepVerifier.create(response)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify();
+    }
+
+    /**
+     * Call mono service given invalid id expected error.
+     */
+    @Test
+    void callMonoService_givenInvalidId_expectedError() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockInvalidClientRequest());
+        StepVerifier.create(response)
+                .expectError()
+                .verify();
+    }
+
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseGetReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseGetReactiveRestClientIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.client.test.client;
+
+import io.americanexpress.synapse.client.rest.client.BaseGetReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@code BaseGetReactiveRestClientIT} is the extensible class for IT testing GET reactive rest clients.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ * @param <C> the reactive client type
+ */
+@ExtendWith(SpringExtension.class)
+public abstract class BaseGetReactiveRestClientIT<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BaseGetReactiveRestClient<I, O>> extends BaseReactiveRestClientIT<I, O, C> {
+
+    /**
+     * Call mono service given valid request expected success response.
+     */
+    @Test
+    void callMonoService_givenValidId_expectedSuccessResponse() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), null, mockPathVariables());
+        StepVerifier.create(response)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify();
+    }
+
+    /**
+     * Call mono service given invalid id expected error.
+     */
+    @Test
+    void callMonoService_givenInvalidId_expectedError() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), null, "invalidId");
+        StepVerifier.create(response)
+                .expectError()
+                .verify();
+    }
+
+    /**
+     * Mock path variables string.
+     *
+     * @return the string
+     */
+    protected abstract String mockPathVariables();
+
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePostReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePostReactiveRestClientIT.java
@@ -14,12 +14,10 @@
 package io.americanexpress.synapse.client.test.client;
 
 import io.americanexpress.synapse.client.rest.client.BasePostReactiveRestClient;
-import io.americanexpress.synapse.client.rest.client.BaseReactiveRestClient;
 import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
 import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
@@ -48,7 +46,7 @@ public abstract class BasePostReactiveRestClientIT<I extends BaseClientRequest,
                 .expectNextCount(1)
                 .expectComplete()
                 .verify();
-    };
+    }
 
     /**
      * Call mono service given invalid id expected error.

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePostReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePostReactiveRestClientIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.client.test.client;
+
+import io.americanexpress.synapse.client.rest.client.BasePostReactiveRestClient;
+import io.americanexpress.synapse.client.rest.client.BaseReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@code BasePostReactiveRestClientIT} is the extensible class for IT testing POST reactive rest clients.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ * @param <C> the reactive client type
+ */
+@ExtendWith(SpringExtension.class)
+public abstract class BasePostReactiveRestClientIT<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BasePostReactiveRestClient<I, O>> extends BaseReactiveRestClientIT<I, O, C> {
+
+
+    /**
+     * Call mono service given valid request expected success response.
+     */
+    @Test
+    void callMonoService_givenValidRequest_expectedSuccessResponse() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockDefaultClientRequest());
+        StepVerifier.create(response)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify();
+    };
+
+    /**
+     * Call mono service given invalid id expected error.
+     */
+    @Test
+    void callMonoService_givenInvalidId_expectedError() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockInvalidClientRequest());
+        StepVerifier.create(response)
+                .expectError()
+                .verify();
+    }
+
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePutReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePutReactiveRestClientIT.java
@@ -13,13 +13,11 @@
  */
 package io.americanexpress.synapse.client.test.client;
 
-import io.americanexpress.synapse.client.rest.client.BasePostReactiveRestClient;
 import io.americanexpress.synapse.client.rest.client.BasePutReactiveRestClient;
 import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
 import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
@@ -47,7 +45,7 @@ public abstract class BasePutReactiveRestClientIT<I extends BaseClientRequest,
                 .expectNextCount(1)
                 .expectComplete()
                 .verify();
-    };
+    }
 
     /**
      * Call mono service given invalid id expected error.

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePutReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BasePutReactiveRestClientIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.client.test.client;
+
+import io.americanexpress.synapse.client.rest.client.BasePostReactiveRestClient;
+import io.americanexpress.synapse.client.rest.client.BasePutReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@code BasePutReactiveRestClientIT} is the extensible class for IT testing PUT reactive rest clients.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ * @param <C> the reactive client type
+ */
+@ExtendWith(SpringExtension.class)
+public abstract class BasePutReactiveRestClientIT<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BasePutReactiveRestClient<I, O>> extends BaseReactiveRestClientIT<I, O, C> {
+
+    /**
+     * Call mono service given valid request expected success response.
+     */
+    @Test
+    void callMonoService_givenValidRequest_expectedSuccessResponse() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockDefaultClientRequest());
+        StepVerifier.create(response)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify();
+    };
+
+    /**
+     * Call mono service given invalid id expected error.
+     */
+    @Test
+    void callMonoService_givenInvalidId_expectedError() {
+        Mono<O> response = client.callMonoService(new HttpHeaders(), mockInvalidClientRequest());
+        StepVerifier.create(response)
+                .expectError()
+                .verify();
+    }
+
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientIT.java
@@ -46,11 +46,6 @@ public abstract class BaseReactiveRestClientIT<I extends BaseClientRequest,
     protected C client;
 
     /**
-     * The Client request.
-     */
-    protected I clientRequest;
-
-    /**
      * Gets default client headers.
      *
      * @return the default client headers

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientIT.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.client.test.client;
+
+import io.americanexpress.synapse.client.rest.client.BaseReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseReactiveRestClientIT} is the base test class for reactive client integration tests.
+ *
+ * @param <I> the input type parameter
+ * @param <O> the output type parameter
+ * @param <C> the reactive client type parameter
+ */
+public abstract class BaseReactiveRestClientIT<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BaseReactiveRestClient<I, O>> extends BaseClientTest {
+
+    /**
+     * Initialize.
+     */
+    @BeforeEach
+    protected void initialize() {
+        this.url = client.getUrl();
+    }
+
+    /**
+     * The Rest client.
+     */
+    @Autowired
+    protected C client;
+
+    /**
+     * The Client request.
+     */
+    protected I clientRequest;
+
+    /**
+     * Gets default client headers.
+     *
+     * @return the default client headers
+     */
+    protected abstract HttpHeaders getDefaultClientHeaders();
+
+    /**
+     * Mock default client request .
+     *
+     * @return the mock client request of type I
+     */
+    protected abstract I mockDefaultClientRequest();
+
+    /**
+     * Mock invalid client request .
+     *
+     * @return the mock invalid client request of type I
+     */
+    protected abstract I mockInvalidClientRequest();
+
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
@@ -1,0 +1,87 @@
+package io.americanexpress.synapse.client.test.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.americanexpress.synapse.client.rest.client.BaseReactiveRestClient;
+import io.americanexpress.synapse.client.rest.model.BaseClientRequest;
+import io.americanexpress.synapse.client.rest.model.BaseClientResponse;
+import io.americanexpress.synapse.framework.exception.ApplicationServerException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@code BaseReactiveRestClientUnitTest} is the base test class for reactive client unit tests.
+ *
+ * @param <I> the input type parameter
+ * @param <O> the output type parameter
+ * @param <C> the client type parameter
+ */
+public abstract class BaseReactiveRestClientUnitTest<I extends BaseClientRequest,
+        O extends BaseClientResponse,
+        C extends BaseReactiveRestClient<I, O>> extends BaseClientTest {
+
+    /**
+     * The Client.
+     */
+    @Autowired
+    C client;
+
+    /**
+     * Call mono service given valid request expected valid response.
+     */
+    @Test
+    void callMonoService_givenValidRequest_expectedValidResponse() {
+        WebClient webClient = WebClient.builder()
+                .exchangeFunction(clientRequest ->
+                {
+                    try {
+                        return Mono.just(ClientResponse.create(HttpStatus.OK)
+                                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .body(mapper.writeValueAsString(mockDefaultClientResponse())).build());
+                    } catch (JsonProcessingException exception) {
+                        throw new ApplicationServerException(exception);
+                    }
+                }).build();
+        client.setWebClient(webClient);
+
+        Mono<O> clientResponse = client.callMonoService(mockClientHeaders(), mockDefaultClientRequest(), mockPathVariables());
+
+        StepVerifier.create(clientResponse)
+                .expectNextCount(1)
+                .expectComplete()
+                .verify();
+    }
+
+    /**
+     * Mock default client request .
+     *
+     * @return the
+     */
+    public abstract I mockDefaultClientRequest();
+
+    /**
+     * Mock default client response o.
+     *
+     * @return the o
+     */
+    public abstract O mockDefaultClientResponse();
+
+    /**
+     * Mock client headers http headers.
+     *
+     * @return the http headers
+     */
+    public abstract HttpHeaders mockClientHeaders();
+
+    /**
+     * Mock path variables string.
+     *
+     * @return the string
+     */
+    public abstract String mockPathVariables();
+}

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -54,7 +55,7 @@ public abstract class BaseReactiveRestClientUnitTest<I extends BaseClientRequest
                 {
                     try {
                         return Mono.just(ClientResponse.create(HttpStatus.OK)
-                                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                                 .body(mapper.writeValueAsString(mockDefaultClientResponse())).build());
                     } catch (JsonProcessingException exception) {
                         throw new ApplicationServerException(exception);

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseReactiveRestClientUnitTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.americanexpress.synapse.client.test.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseRestClientUnitTest.java
+++ b/client/synapse-client-test/src/main/java/io/americanexpress/synapse/client/test/client/BaseRestClientUnitTest.java
@@ -54,7 +54,8 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
         O extends BaseClientResponse,
         C extends BaseRestClient<I, O>> extends BaseRestClientTest<I, O, C> {
 
-	protected O clientResponse;
+    public static final String CLIENT_RESPONSE = "Client response {}";
+    protected O clientResponse;
 
     protected HttpHeaders headers;
 
@@ -77,7 +78,7 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
         O actual = restClient.callMonoService(headers, clientRequest);
         mockServer.verify();
         assertNotNull(actual, CommonAssertionMessages.RESPONSE_IS_NULL);
-        logger.debug("Client response {}", actual);
+        logger.debug(CLIENT_RESPONSE, actual);
     }
 
     @Test
@@ -102,7 +103,7 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
         // Assert that the expectations have been met
         pathVariableMockServer.verify();
         assertNotNull(actual, CommonAssertionMessages.RESPONSE_IS_NULL);
-        logger.debug("Client response {}", actual);
+        logger.debug(CLIENT_RESPONSE, actual);
     }
 
     @Test
@@ -125,7 +126,7 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
         O actual = restClient.callMonoService(headers, clientRequest, mockQueryParameter());
         queryParameterMockServer.verify();
         assertNotNull(actual, CommonAssertionMessages.RESPONSE_IS_NULL);
-        logger.debug("Client response {}", actual);
+        logger.debug(CLIENT_RESPONSE, actual);
     }
 
     @Test
@@ -148,7 +149,7 @@ public abstract class BaseRestClientUnitTest<I extends BaseClientRequest,
         O actual = restClient.callMonoService(headers, clientRequest, mockQueryParameter(), mockPathVariable());
         queryParameterMockServer.verify();
         assertNotNull(actual, CommonAssertionMessages.RESPONSE_IS_NULL);
-        logger.debug("Client response {}", actual);
+        logger.debug(CLIENT_RESPONSE, actual);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -1020,6 +1020,13 @@
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>
+
+            <!--Reactor-->
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-test</artifactId>
+                <version>3.5.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR contains code to add base IT tests for reactive clients in synapse-client-test.