### PR TITLE
feat: add case for partial content to BaseControllerTest

### DIFF
--- a/service/synapse-service-test/src/main/java/io/americanexpress/synapse/service/test/controller/BaseControllerTest.java
+++ b/service/synapse-service-test/src/main/java/io/americanexpress/synapse/service/test/controller/BaseControllerTest.java
@@ -241,7 +241,10 @@ public abstract class BaseControllerTest<O extends BaseServiceResponse> {
                 resultActions.andExpect(MockMvcResultMatchers.status().isUnauthorized());
             } else if (HttpStatus.NO_CONTENT.equals(httpStatusExpected)) {
                 resultActions.andExpect(MockMvcResultMatchers.status().isNoContent());
-            } else {
+            } else if (HttpStatus.PARTIAL_CONTENT.equals(httpStatusExpected)) {
+                resultActions.andExpect(MockMvcResultMatchers.status().isPartialContent());
+            }
+            else {
                 Assertions.fail();
             }
         }


### PR DESCRIPTION
While writing tests for Identity Resolution service, I noticed that controller tests that expected Partial Content were failing.

The base test class logic didn't have a check for partial content and was always just failing the assertion.