### PR TITLE
bugfix(service-reactive-rest): adding logging for errors, shouldNotFilter

### DIFF
--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -28,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.server.WebExceptionHandler;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -63,6 +64,9 @@ public class ControllerExceptionHandler implements WebExceptionHandler {
         if (throwable instanceof WebExchangeBindException webExchangeBindException) {
             exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
             errorResponse = inputValidationErrorHandler.handleInputValidationErrorMessage(webExchangeBindException);
+        } else if (throwable instanceof ServerWebInputException serverWebInputException) {
+            exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+            errorResponse = new ErrorResponse(ErrorCode.GENERIC_4XX_ERROR, serverWebInputException.getMessage(), throwable.getMessage(), serverWebInputException.getLocalizedMessage());
         } else if (throwable instanceof ApplicationClientException applicationClientException) {
             exchange.getResponse().setStatusCode(applicationClientException.getErrorCode().getHttpStatus());
             errorResponse = new ErrorResponse(applicationClientException.getErrorCode(), applicationClientException.getErrorCode().getMessage(),

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -86,9 +86,11 @@ public class ControllerExceptionHandler implements WebExceptionHandler {
         DataBuffer buffer;
         try {
             buffer = exchange.getResponse().bufferFactory().wrap(new ObjectMapper().writeValueAsBytes(errorResponse));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+        } catch (JsonProcessingException exception) {
+            throw new ApplicationServerException(exception);
         }
+
+        exchange.getResponse().setStatusCode(errorResponse.getCode().getHttpStatus());
         exchange.getResponse().getHeaders().add("Content-Type", "application/json");
         return exchange.getResponse().writeWith(Flux.just(buffer));
     }
@@ -99,7 +101,7 @@ public class ControllerExceptionHandler implements WebExceptionHandler {
      * @return the error response
      */
     public ErrorResponse handleInternalServerError(Throwable throwable) {
-        logger.catching(throwable);
+        logger.warn("Error", throwable);
         return new ErrorResponse(ErrorCode.GENERIC_5XX_ERROR, ErrorCode.GENERIC_5XX_ERROR.getMessage(), throwable.getMessage(),
                 ApplicationServerException.getStackTrace(throwable, System.lineSeparator()));
     }

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/filter/BaseHttpHeadersFilter.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/filter/BaseHttpHeadersFilter.java
@@ -68,6 +68,8 @@ public abstract class BaseHttpHeadersFilter implements WebFilter {
 
     /**
      * Subclasses can override this method to control what requests should not be filtered.
+     * for example override the method with the following to prevent
+     * health endpoint : return request.getURI().getPath().equals("/health")
      *
      * @param request the incoming request
      * @return true if url should not be filtered


### PR DESCRIPTION
This PR contains code to make changes to synapse-service-reactive-rest to:
- add logging for errors
- fix http status in response for errors
- add shouldNotFilter for required headers check