### PR TITLE
bugfix(): fixed org.springframework.data.domain.ManagedTypes exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@
             <dependency>
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-r2dbc</artifactId>
-                <version>3.1.0</version>
+                <version>1.5.14</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.plugin</groupId>


### PR DESCRIPTION
The changes in this PR resolves the issue below:

`Caused by: java.lang.NoClassDefFoundError: org/springframework/data/domain/ManagedTypes
	at java.lang.Class.getDeclaredMethods0(Native Method) ~[?:?]
	at java.lang.Class.privateGetDeclaredMethods(Class.java:3402) ~[?:?]
	at java.lang.Class.getDeclaredMethods(Class.java:2504) ~[?:?]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:467) ~[spring-core-5.3.23.jar:5.3.23]
	... 21 more
Caused by: java.lang.ClassNotFoundException: org.springframework.data.domain.ManagedTypes
	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[?:?]
	at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[?:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
	at java.lang.Class.getDeclaredMethods0(Native Method) ~[?:?]
	at java.lang.Class.privateGetDeclaredMethods(Class.java:3402) ~[?:?]
	at java.lang.Class.getDeclaredMethods(Class.java:2504) ~[?:?]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:467) ~[spring-core-5.3.23.jar:5.3.23]`