### PR TITLE
fix: change body to be mono for call poly service

### DIFF
--- a/client/synapse-client-rest/src/main/java/io/americanexpress/synapse/client/rest/client/BaseReactiveRestClient.java
+++ b/client/synapse-client-rest/src/main/java/io/americanexpress/synapse/client/rest/client/BaseReactiveRestClient.java
@@ -166,7 +166,7 @@ public abstract class BaseReactiveRestClient<I extends BaseClientRequest, O exte
 			.uri(updatedUrl)
 			.headers(httpHeaders ->
 				httpHeaders.addAll(httpHeadersFactory.create(headers, clientRequest, updatedUrl)))
-			.body(Flux.just(clientRequest), clientRequestType)
+			.body(Mono.just(clientRequest), clientRequestType)
 			.retrieve()
 			.onStatus(HttpStatus::isError, reactiveRestResponseErrorHandler)
 			.bodyToFlux(clientResponseType);


### PR DESCRIPTION
Fixes the request body for callPolyService. Requests were timing out with Flux.just