### PR TITLE
Version fix in data module

### DIFF
--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.3.21-SNAPSHOT</version>
+        <version>0.3.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-pool</artifactId>
-            <version>1.0.0.RELEASE</version>
         </dependency>
         <!-- Test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -765,6 +765,13 @@
                 <version>1.0.0.RC1</version>
             </dependency>
 
+            <!-- Data Pool -->
+            <dependency>
+                <groupId>io.r2dbc</groupId>
+                <artifactId>r2dbc-pool</artifactId>
+                <version>1.0.0.RELEASE</version>
+            </dependency>
+
             <!--MSSQL-->
             <dependency>
                 <groupId>io.r2dbc</groupId>

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.3.21-SNAPSHOT</version>
+        <version>0.3.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
There was an issue while building (if building for the first time), where the data `sample-data-oracle-reactive-cp-book` module was looking for version `0.3.21-SNAPSHOT` as the parent module. For first timers pulling and building the code locally, this would be a breaking change, since they won't have version `0.3.21-SNAPSHOT`. I bumped up the version to `0.3.23-SNAPSHOT`, which is the correct one.

Also, I moved the `r2dbc-pool` pom version from the data module, to the dependency manager pom file, where we manage all the dependencies.