### PR TITLE
ApplicationException Handler

### DIFF
--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
@@ -1,0 +1,47 @@
+package io.americanexpress.synapse.framework.exception;
+
+import io.americanexpress.synapse.framework.exception.model.ExceptionCode;
+
+/**
+ * {@code ApplicationException} used for exceptions throws at layers that are not related to any request protocol.
+ *
+ * @author John Robert Martinez Ponce
+ */
+public class ApplicationException extends RuntimeException {
+
+    private String developerMessage;
+
+    private ExceptionCode exceptionCode;
+
+    private String[] messageArguments;
+
+    public ApplicationException(String developerMessage, ExceptionCode exceptionCode, String[] messageArguments) {
+        this.developerMessage = developerMessage;
+        this.exceptionCode = exceptionCode;
+        this.messageArguments = messageArguments;
+    }
+
+    public String getDeveloperMessage() {
+        return developerMessage;
+    }
+
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+
+    public void setExceptionCode(ExceptionCode exceptionCode) {
+        this.exceptionCode = exceptionCode;
+    }
+
+    public String[] getMessageArguments() {
+        return messageArguments;
+    }
+
+    public void setMessageArguments(String[] messageArguments) {
+        this.messageArguments = messageArguments;
+    }
+}

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
@@ -9,9 +9,9 @@ import io.americanexpress.synapse.framework.exception.model.ExceptionCode;
  */
 public class ApplicationException extends RuntimeException {
 
-    private String developerMessage;
+    private final String developerMessage;
 
-    private ExceptionCode exceptionCode;
+    private final ExceptionCode exceptionCode;
 
     private String[] messageArguments;
 
@@ -30,16 +30,8 @@ public class ApplicationException extends RuntimeException {
         return developerMessage;
     }
 
-    public void setDeveloperMessage(String developerMessage) {
-        this.developerMessage = developerMessage;
-    }
-
     public ExceptionCode getExceptionCode() {
         return exceptionCode;
-    }
-
-    public void setExceptionCode(ExceptionCode exceptionCode) {
-        this.exceptionCode = exceptionCode;
     }
 
     public String[] getMessageArguments() {

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
@@ -15,7 +15,7 @@ public class ApplicationException extends RuntimeException {
 
     private String[] messageArguments;
 
-    public ApplicationException(String developerMessage, ExceptionCode exceptionCode, String[] messageArguments) {
+    public ApplicationException(ExceptionCode exceptionCode, String developerMessage, String[] messageArguments) {
         this.developerMessage = developerMessage;
         this.exceptionCode = exceptionCode;
         this.messageArguments = messageArguments;

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/ApplicationException.java
@@ -21,6 +21,11 @@ public class ApplicationException extends RuntimeException {
         this.messageArguments = messageArguments;
     }
 
+    public ApplicationException(ExceptionCode exceptionCode, String developerMessage) {
+        this.developerMessage = developerMessage;
+        this.exceptionCode = exceptionCode;
+    }
+
     public String getDeveloperMessage() {
         return developerMessage;
     }

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/BaseControllerExceptionHandler.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/BaseControllerExceptionHandler.java
@@ -1,0 +1,35 @@
+package io.americanexpress.synapse.framework.exception;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import io.americanexpress.synapse.framework.exception.model.ExceptionCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.Arrays;
+
+public abstract class BaseControllerExceptionHandler<T, R, E> {
+
+    /**
+     * Used to log the exceptions.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    @ExceptionHandler(ApplicationException.class)
+    public T handleApplicationException(final ApplicationException applicationException) {
+
+        E errorCode = mapExceptionCode(applicationException.getExceptionCode());
+        ErrorResponse errorResponse = new ErrorResponse(
+                errorCode,
+                errorCode.getMessage(),
+                applicationException.getMessageArguments() == null ? null : Arrays.toString(applicationException.getMessageArguments()),
+                applicationException.getDeveloperMessage() == null ? null : applicationException.getDeveloperMessage()
+        );
+
+        return createExceptionResponse(errorResponse);
+    }
+
+    abstract T createExceptionResponse(R response);
+
+    protected abstract ErrorCode mapExceptionCode(ExceptionCode exceptionCode);
+
+}

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ExceptionCode.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ExceptionCode.java
@@ -1,0 +1,40 @@
+package io.americanexpress.synapse.framework.exception.model;
+
+/**
+ * {@code ExceptionCode} contains a list of generic exception codes, that area going to be used to provide more
+ * information about the Exception.
+ *
+ * @author John Robert Martinez Ponce
+ */
+public enum ExceptionCode {
+
+    /**
+     * Used for when a validation did not proceed as expected.
+     */
+    VALIDATION_EXCEPTION("Invalid data"),
+
+    /**
+     * Used for when a data point was not found.
+     */
+    NOT_FOUND("Data not found"),
+
+    /**
+     * Used for processes that are interrupted in the middle of a transaction.
+     */
+    UNABLE_PROCESS("Unable to process");
+
+    private final String message;
+
+    ExceptionCode(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Retrieves the static exception message from the ENUM.
+     *
+     * @return a String with the message
+     */
+    public String getMessage() {
+        return message;
+    }
+}

--- a/service/synapse-service-graphql/src/main/java/io/americanexpress/synapse/service/graphql/model/ReactiveResponseCreator.java
+++ b/service/synapse-service-graphql/src/main/java/io/americanexpress/synapse/service/graphql/model/ReactiveResponseCreator.java
@@ -13,44 +13,46 @@
  */
 package io.americanexpress.synapse.service.graphql.model;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 /**
  * {@code ReactiveResponseCreator} class creates reactive responses.
- * @author Paolo Claudio
  *
+ * @author Paolo Claudio
  */
 public final class ReactiveResponseCreator {
 
-	/**
-	 * Default constructor creates a new instance of ReactiveResponseCreator with default values.
-	 */
-	private ReactiveResponseCreator() {
-		
-		// A class containing only static methods is a utility class that requires a private default constructor
-	}
-	
-	/**
-	 * Create the reactive response.
-	 * @param element to be set in the response
-	 * @return the reactive response
-	 */
-	public static final <T> CompletableFuture<T> create(T element) {
-		return Mono.fromSupplier(() -> element).toFuture();
-	}
-	
-	/**
-	 * Create the reactive response.
-	 * @param elements to be set in the response
-	 * @return the reactive response
-	 */
-	public static final <T> CompletableFuture<List<T>> create(List<T> elements) {
-		return Flux.fromIterable(elements)
-			.collectList()
-			.toFuture();
-	}
+    /**
+     * Default constructor creates a new instance of ReactiveResponseCreator with default values.
+     */
+    private ReactiveResponseCreator() {
+
+        // A class containing only static methods is a utility class that requires a private default constructor
+    }
+
+    /**
+     * Create the reactive response.
+     *
+     * @param element to be set in the response
+     * @return the reactive response
+     */
+    public static <T> CompletableFuture<T> create(T element) {
+        return Mono.fromSupplier(() -> element).toFuture();
+    }
+
+    /**
+     * Create the reactive response.
+     *
+     * @param elements to be set in the response
+     * @return the reactive response
+     */
+    public static <T> CompletableFuture<List<T>> create(List<T> elements) {
+        return Flux.fromIterable(elements)
+                .collectList()
+                .toFuture();
+    }
 }

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -116,8 +116,7 @@ public class ControllerExceptionHandler {
      * Creates a mapping between the generic {@link ApplicationException} object and the REST ResponseEntity, so that the
      * API can return the correct response status code and messages in case of an exception.
      * <p>
-     * This is done, so that we could
-     * extract the business exception vs the REST layer.
+     * This is done, so that we could extract the business exception vs the REST layer.
      *
      * @param applicationException generic exception object that would be used to map to the REST exception ResponseEntity
      * @return an object of type {@link ResponseEntity<ErrorResponse>}

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -124,7 +124,7 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> handleApplicationException(final ApplicationException applicationException) {
         logger.entry(applicationException);
-        ErrorCode errorCode = mapErrorCode(applicationException.getExceptionCode());
+        ErrorCode errorCode = mapExceptionCode(applicationException.getExceptionCode());
         ErrorResponse errorResponse = new ErrorResponse(
                 errorCode,
                 errorCode.getMessage(),
@@ -142,7 +142,7 @@ public class ControllerExceptionHandler {
      * @param exceptionCode generic ENUM that is associated with a business exception
      * @return a value from ENUM {@link ErrorCode}
      */
-    private ErrorCode mapErrorCode(ExceptionCode exceptionCode) {
+    private ErrorCode mapExceptionCode(ExceptionCode exceptionCode) {
         return switch (exceptionCode) {
             case VALIDATION_EXCEPTION -> ErrorCode.GENERIC_4XX_ERROR;
             case NOT_FOUND -> ErrorCode.NOT_FOUND;

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -16,6 +16,7 @@ package io.americanexpress.synapse.service.rest.controller.exceptionhandler;
 import io.americanexpress.synapse.framework.exception.ApplicationClientException;
 import io.americanexpress.synapse.framework.exception.ApplicationException;
 import io.americanexpress.synapse.framework.exception.ApplicationServerException;
+import io.americanexpress.synapse.framework.exception.BaseControllerExceptionHandler;
 import io.americanexpress.synapse.framework.exception.helper.ErrorMessagePropertyReader;
 import io.americanexpress.synapse.framework.exception.model.ErrorCode;
 import io.americanexpress.synapse.framework.exception.model.ExceptionCode;
@@ -42,7 +43,7 @@ import java.util.Arrays;
  * @author Alexei Morgado
  */
 @RestControllerAdvice
-public class ControllerExceptionHandler {
+public class ControllerExceptionHandler extends BaseControllerExceptionHandler {
     /**
      * Used to log the exceptions.
      */
@@ -133,7 +134,6 @@ public class ControllerExceptionHandler {
         );
         logger.exit(errorResponse);
         return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
-
     }
 
     /**
@@ -142,7 +142,8 @@ public class ControllerExceptionHandler {
      * @param exceptionCode generic ENUM that is associated with a business exception
      * @return a value from ENUM {@link ErrorCode}
      */
-    private ErrorCode mapExceptionCode(ExceptionCode exceptionCode) {
+    @Override
+    ErrorCode mapExceptionCode(ExceptionCode exceptionCode) {
         return switch (exceptionCode) {
             case VALIDATION_EXCEPTION -> ErrorCode.GENERIC_4XX_ERROR;
             case NOT_FOUND -> ErrorCode.NOT_FOUND;

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -129,7 +129,7 @@ public class ControllerExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(
                 errorCode,
                 errorCode.getMessage(),
-                Arrays.toString(applicationException.getMessageArguments()),
+                applicationException.getMessageArguments() == null ? null : Arrays.toString(applicationException.getMessageArguments()),
                 applicationException.getDeveloperMessage() == null ? null : applicationException.getDeveloperMessage()
         );
         logger.exit(errorResponse);

--- a/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
+++ b/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
@@ -20,6 +20,7 @@ import io.americanexpress.synapse.framework.exception.helper.ErrorMessagePropert
 import io.americanexpress.synapse.framework.exception.model.ErrorCode;
 import io.americanexpress.synapse.framework.exception.model.ExceptionCode;
 import io.americanexpress.synapse.service.rest.model.ErrorResponse;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -42,7 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -145,10 +147,10 @@ class ControllerExceptionHandlerTest {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.VALIDATION_EXCEPTION, "Some kind of exception", new String[]{"arg1", "arg2"}));
         assertAll(
-                () -> assertEquals(ErrorCode.GENERIC_4XX_ERROR.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
-                () -> assertEquals(ErrorCode.GENERIC_4XX_ERROR.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
-                () -> assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
-                () -> assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "[arg1, arg2]", "ApplicationException more info doesn't match.")
+                () -> Assertions.assertEquals(ErrorCode.GENERIC_4XX_ERROR.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
+                () -> Assertions.assertEquals(ErrorCode.GENERIC_4XX_ERROR.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
+                () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
+                () -> Assertions.assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "[arg1, arg2]", "ApplicationException more info doesn't match.")
         );
     }
 
@@ -158,11 +160,11 @@ class ControllerExceptionHandlerTest {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.NOT_FOUND, "Data not found", new String[]{"arg1", "arg2"}));
         assertAll(
-                () -> assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
-                () -> assertEquals(ErrorCode.NOT_FOUND.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
-                () -> assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
-                () -> assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "[arg1, arg2]", "ApplicationException more info doesn't match.")
-        );
+                () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
+                () -> Assertions.assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), ErrorCode.NOT_FOUND.getMessage(), "ApplicationException message do not match."),
+                () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(),"ApplicationException's developer message is null."),
+                () -> Assertions.assertEquals("[arg1, arg2]", Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "ApplicationException more info doesn't match.")
+                        );
     }
 
     @Test
@@ -170,10 +172,10 @@ class ControllerExceptionHandlerTest {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.NOT_FOUND, "Data not found"));
         assertAll(
-                () -> assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
-                () -> assertEquals(ErrorCode.NOT_FOUND.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
-                () -> assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
-                () -> assertNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "ApplicationException moreInfo is not null as expected.")
+                () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
+                () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
+                () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
+                () -> Assertions.assertNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "ApplicationException moreInfo is not null as expected.")
         );
     }
 }

--- a/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
+++ b/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
@@ -164,4 +164,16 @@ class ControllerExceptionHandlerTest {
                 () -> assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "[arg1, arg2]", "ApplicationException more info doesn't match.")
         );
     }
+
+    @Test
+    void handleApplicationException_givenNoArguments_expectsSuccess() {
+        ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
+        var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.NOT_FOUND, "Data not found"));
+        assertAll(
+                () -> assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
+                () -> assertEquals(ErrorCode.NOT_FOUND.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
+                () -> assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
+                () -> assertNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "ApplicationException moreInfo is not null as expected.")
+        );
+    }
 }

--- a/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
+++ b/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 

--- a/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
+++ b/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
@@ -43,8 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
+++ b/service/synapse-service-rest/src/test/java/io/americanexpress/synapse/service/rest/controller/exceptionhandler/ControllerExceptionHandlerTest.java
@@ -146,7 +146,7 @@ class ControllerExceptionHandlerTest {
     void handleApplicationException() {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.VALIDATION_EXCEPTION, "Some kind of exception", new String[]{"arg1", "arg2"}));
-        assertAll(
+        Assertions.assertAll(
                 () -> Assertions.assertEquals(ErrorCode.GENERIC_4XX_ERROR.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
                 () -> Assertions.assertEquals(ErrorCode.GENERIC_4XX_ERROR.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
                 () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),
@@ -159,19 +159,19 @@ class ControllerExceptionHandlerTest {
     void handleApplicationException_givenDataNotFound_expectsGeneric4XXError() {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.NOT_FOUND, "Data not found", new String[]{"arg1", "arg2"}));
-        assertAll(
+        Assertions.assertAll(
                 () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
                 () -> Assertions.assertEquals(Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), ErrorCode.NOT_FOUND.getMessage(), "ApplicationException message do not match."),
                 () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(),"ApplicationException's developer message is null."),
                 () -> Assertions.assertEquals("[arg1, arg2]", Objects.requireNonNull(applicationExceptionResponse.getBody()).getMoreInfo(), "ApplicationException more info doesn't match.")
-                        );
+        );
     }
 
     @Test
     void handleApplicationException_givenNoArguments_expectsSuccess() {
         ControllerExceptionHandler controllerExceptionHandler = new ControllerExceptionHandler(errorMessagePropertyReader, inputValidationErrorHandler);
         var applicationExceptionResponse = controllerExceptionHandler.handleApplicationException(new ApplicationException(ExceptionCode.NOT_FOUND, "Data not found"));
-        assertAll(
+        Assertions.assertAll(
                 () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getHttpStatus(), applicationExceptionResponse.getStatusCode(), "ApplicationException status code don't match."),
                 () -> Assertions.assertEquals(ErrorCode.NOT_FOUND.getMessage(), Objects.requireNonNull(applicationExceptionResponse.getBody()).getMessage(), "ApplicationException message do not match."),
                 () -> Assertions.assertNotNull(Objects.requireNonNull(applicationExceptionResponse.getBody()).getDeveloperMessage(), "ApplicationException's developer message is null."),


### PR DESCRIPTION
In this PR, I am adding a new exception handler, which extracts the Exception from the http/gRPC/GraphQL layer. The exceptions thrown in the ApplicationException class are generic and not associated to the API layer, later to be introduced. Also, I have added the mapping for the REST layer that lays on the ControllerAdvice class. Unit testing was also added to make sure the mapping to the REST layer is working as expected.