### PR TITLE
feat(synapse-service-reactive): adding synapse-service-reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
             </dependency>
             <dependency>
                 <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-service-reactive</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
                 <artifactId>synapse-service-reactive-rest</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -28,6 +28,7 @@
     <modules>
         <module>service-samples</module>
         <module>synapse-service-graphql</module>
+        <module>synapse-service-reactive</module>
         <module>synapse-service-reactive-rest</module>
         <module>synapse-service-rest</module>
         <module>synapse-service-test</module>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -15,20 +15,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
-        <artifactId>synapse</artifactId>
+        <artifactId>service</artifactId>
         <version>0.3.28-SNAPSHOT</version>
     </parent>
 
+    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-reactive</artifactId>
-
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>synapse</artifactId>
+        <version>0.3.28-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>synapse-service-reactive</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <!--Dependencies-->
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+
+        <!--Spring-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/config/BaseReactiveServiceRestConfig.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/config/BaseReactiveServiceRestConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+/**
+ * {@code BaseServiceReactiveRestConfig} sets common configurations for the service layer.
+ * @author Francois Gutt
+ */
+@Configuration
+@EnableWebFlux
+@ComponentScan(basePackages = "io.americanexpress.synapse.service.reactive")
+@Import({ExceptionConfig.class, ApiDocsConfig.class, UtilitiesCommonConfig.class})
+public class BaseReactiveServiceRestConfig implements WebFluxConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Constructor taking in objectMapper.
+     * @param defaultObjectMapper   the default object mapper.
+     */
+    @Autowired
+    public BaseReactiveServiceRestConfig(ObjectMapper defaultObjectMapper) {
+        this.defaultObjectMapper = defaultObjectMapper;
+    }
+
+    /**
+     * Configures the HTTP message readers and writers for reading from the request body and
+     * for writing to the response body in annotated controllers and functional endpoints.
+     * @param configurer the service codec configurer
+     */
+    @Override
+    public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+        configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(getObjectMapper()));
+        configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(getObjectMapper()));
+    }
+
+    /**
+     * Returns default objectMapper.
+     * @return an object mapper
+     */
+    protected ObjectMapper getObjectMapper() {
+        return defaultObjectMapper;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BasePaginatedServiceRequest.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BasePaginatedServiceRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code BasePaginatedServiceRequest} should be used when pagination is needed in a Poly Controller.
+ * @author Francois Gutt
+ */
+public abstract class BasePaginatedServiceRequest extends BaseServiceRequest {
+
+    /**
+     * Used for services that support pagination.
+     */
+    private PageInformation pageInformation;
+
+    /**
+     * Get the pageInformation.
+     * @return the pageInformation
+     */
+    public PageInformation getPageInformation() {
+        return pageInformation;
+    }
+
+    /**
+     * Set the pageInformation.
+     * @param pageInformation the pageInformation to set
+     */
+    public void setPageInformation(PageInformation pageInformation) {
+        this.pageInformation = pageInformation;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceRequest.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+import java.util.Map;
+
+/**
+ * {@code BaseServiceRequest} specifies the prototypes for all service requests.
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceRequest {
+
+    /**
+     * The service header map.
+     */
+    private Map<String, String> serviceHeaders;
+
+    /**
+     * Get the service headers map
+     * @return a map of service headers
+     */
+    public Map<String, String> getServiceHeaders() {
+        return serviceHeaders;
+    }
+
+    /**
+     * Sets the service header map.
+     * @param serviceHeaders a mapl of service headers.
+     */
+    public void setServiceHeaders(Map<String, String> serviceHeaders) {
+        this.serviceHeaders = serviceHeaders;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceResponse.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code BaseServiceResponse} specifies the prototypes for all service responses.
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceResponse {
+
+    /**
+     * Id used to uniquely get, update or remove a resource.
+     */
+    protected String id;
+
+    /**
+     * Get the id.
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the id.
+     * @param id the identifier to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ErrorResponse.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ErrorResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+
+/**
+ * {@code ErrorResponse} class is the response model for 4XX and 5XX series errors.
+ * @author Francois Gutt
+ */
+public class ErrorResponse {
+
+    /**
+     * Error code.
+     */
+    private ErrorCode code;
+
+    /**
+     * Friendly header message that gives a brief overview of the error.
+     */
+    private String message;
+
+    /**
+     * Friendly user message to the consumer of the error.
+     */
+    private String moreInfo;
+
+    /**
+     * Message for the developer of the error and possibly a solution to fix the error.
+     */
+    private String developerMessage;
+
+    /**
+     * Creates a new instance of ErrorResponse with given values.
+     *
+     * @param code             error code
+     * @param message          friendly header message that gives a brief overview of the error
+     * @param moreInfo         friendly user message to the consumer of the error
+     * @param developerMessage message for the developer of the error and possibly a solution to fix the error
+     */
+    public ErrorResponse(ErrorCode code, String message, String moreInfo, String developerMessage) {
+        this.code = code;
+        this.message = message;
+        this.moreInfo = moreInfo;
+        this.developerMessage = developerMessage;
+    }
+
+    /**
+     * Get the errorCode.
+     * @return the errorCode
+     */
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    /**
+     * Get the userMessage.
+     * @return the userMessage
+     */
+    public String getMoreInfo() {
+        return moreInfo;
+    }
+
+    /**
+     * Get the headerMessage.
+     * @return the headerMessage
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Get the developerMessage.
+     * @return the developerMessage
+     */
+    public String getDeveloperMessage() {
+        return developerMessage;
+    }
+
+    /**
+     * Set the developerMessage.
+     * @param developerMessage the developerMessage
+     */
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ExposedHeaders.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ExposedHeaders.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code ExposedHeaders} enum has the names of the exposed HTTP headers that can be discovered in addition to the standard response HTTP headers that are exposed by Spring.
+ * @author Paolo Claudio
+ */
+public enum ExposedHeaders {
+
+    PAGE("Page"), SIZE("Size"), TOTAL_RESULTS_COUNT("Total-Results-Count");
+
+    /**
+     * Name of the exposed header.
+     */
+    private String name;
+
+    /**
+     * Argument constructor creates a new instance of ExposedHeaders with given values.
+     * @param name of the exposed header
+     */
+    ExposedHeaders(String name) {
+        setName(name);
+    }
+
+    /**
+     * Get the name.
+     * @return the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the name.
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/PageInformation.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/PageInformation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code PageInformation} class specifies the parameters for a service request,
+ * limiting the results to a subset of how many (size) and on which page (page).
+ * @author Francois Gutt
+ */
+public class PageInformation {
+
+    /**
+     * The page requested of the results.
+     */
+    private int page;
+
+    /**
+     * The number of results per page.
+     */
+    private int size;
+
+    /**
+     * Get the page.
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     * @param page the page to set
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * Get the size.
+     * @return the size
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Set the size.
+     * @param size the size to set
+     */
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseCreateReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseCreateReactiveService.java
@@ -1,0 +1,52 @@
+package io.americanexpress.synapse.service.reactive.service;
+
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseCreateReactiveService} specifies the prototypes for performing business logic.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseCreateReactiveService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Add a single resource.
+     *
+     * @param headers the headers
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    public Mono<O> create(HttpHeaders headers, I request) {
+        logger.entry(request);
+        final var response = executeCreate(headers,request);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for adding a resource.
+     *
+     * @param headers the headers
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    protected abstract Mono<O> executeCreate(HttpHeaders headers,I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseDeleteReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseDeleteReactiveService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseDeleteReactiveService} class specifies the prototypes for performing business logic.
+ * @author Francois Gutt
+ */
+public abstract class BaseDeleteReactiveService extends BaseService {
+
+    /**
+     * Deletes a resource by id.
+     * @param headers containing the HTTP headers from the consumer
+     * @param identifier an identifier
+     * @return a mono void
+     */
+    public Mono<Void> delete(HttpHeaders headers, String identifier) {
+        logger.entry();
+        var results = executeDelete(headers, identifier);
+        logger.exit();
+        return results;
+    }
+
+    /**
+     * Prototype for deleting a resource.
+     * @param headers containing the HTTP headers from the consumer
+     * @param identifier an identifier
+     * @return a mono void
+     */
+    protected abstract Mono<Void> executeDelete(HttpHeaders headers, String identifier);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetFluxReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetFluxReactiveService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@code BaseGetFluxReactiveService} class specifies the prototypes for performing business logic.
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseGetFluxReactiveService<O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Retrieves multiple resource.
+     * @param headers headers
+     * @return a flux read response
+     */
+    public Flux<O> read(HttpHeaders headers) {
+        logger.entry();
+        var response = executeRead(headers);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     * @param headers headers
+     * @return a flux read response
+     */
+    protected abstract Flux<O> executeRead(HttpHeaders headers);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetMonoReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetMonoReactiveService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseGetMonoReactiveService} class specifies the prototypes for performing business logic.
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseGetMonoReactiveService<O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Retrieves one resource.
+     * @param headers headers
+     * @param identifier an identifier
+     * @return a mono read response
+     */
+    public Mono<O> read(HttpHeaders headers, String identifier) {
+        logger.entry(identifier);
+        final var response = executeRead(headers, identifier);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     * @param headers headers
+     * @param request an identifier
+     * @return a mono read response
+     */
+    protected abstract Mono<O> executeRead(HttpHeaders headers, String request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadFluxReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadFluxReactiveService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@code BaseReadFluxReactiveService} class specifies the prototypes for performing business logic.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadFluxReactiveService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Retrieves multiple resources with a request body.
+     * @param headers headers
+     * @param request a base service request
+     * @return a flux read response
+     */
+    public Flux<O> read(HttpHeaders headers, final I request) {
+        logger.entry(request);
+        final var response  = executeRead(headers, request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     * @param headers headers
+     * @param request a base service request
+     * @return a flux read response
+     */
+    protected abstract Flux<O> executeRead(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadMonoReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadMonoReactiveService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseReadMonoReactiveService} class specifies the prototypes for performing business logic.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadMonoReactiveService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Retrieves one resource with a request body.
+     *
+     * @param headers headers
+     * @param request a service request
+     * @return a mono service response
+     */
+    public Mono<O> read(HttpHeaders headers, I request) {
+        logger.entry(request);
+        final var response = executeRead(headers, request);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     *
+     * @param headers headers
+     * @param request a service request
+     * @return a mono service response
+     */
+    protected abstract Mono<O> executeRead(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+
+/**
+ * {@code BaseService} specifies the prototypes for all services.
+ * @author Francois Gutt
+ */
+public abstract class BaseService {
+
+    /**
+     * Logger for the base service.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(getClass());
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseUpdateReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseUpdateReactiveService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseUpdateReactiveService} class specifies the prototypes for performing business logic.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @author Francois Gutt
+ */
+public abstract class BaseUpdateReactiveService<I extends BaseServiceRequest> extends BaseService {
+
+    /**
+     * Update a single resource reactively.
+     *
+     * @param headers headers
+     * @param request body received from the controller
+     * @return a mono void
+     */
+    public Mono<Void> update(HttpHeaders headers, I request) {
+        logger.entry(request);
+        var results = executeUpdate(headers, request);
+        logger.exit();
+        return results;
+    }
+
+    /**
+     * Prototype for updating a resource.
+     *
+     * @param headers the headers
+     * @param request body received from the controller
+     * @return a mono void
+     */
+    protected abstract Mono<Void> executeUpdate(HttpHeaders headers, I request);
+}


### PR DESCRIPTION
# Synapse Service Reactive

## Description

Synapse Service Reactive allows for business logic implementation without the protocol layer therefore leaving the developer free to implement the business logic and making the protocol layer interchangeable.

## Changes in this PR
- config
- models
- services