### PR TITLE
feat(synapse-service-imperative): creating the synapse-service-impera…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
             </dependency>
             <dependency>
                 <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-service-imperative</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
                 <artifactId>synapse-service-reactive-rest</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -28,6 +28,7 @@
     <modules>
         <module>service-samples</module>
         <module>synapse-service-graphql</module>
+        <module>synapse-service-imperative</module>
         <module>synapse-service-reactive-rest</module>
         <module>synapse-service-rest</module>
         <module>synapse-service-test</module>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service</artifactId>
+        <version>0.3.28-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>synapse-service-imperative</artifactId>
+
+    <!--Dependencies-->
+    <dependencies>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-test</artifactId>
+        </dependency>
+
+
+        <!--External Dependencies-->
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+
+        <!--Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+
+
+        <!--Spring Boot-->
+        <dependency>
+            <groupId>org.springframework.plugin</groupId>
+            <artifactId>spring-plugin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!--TOMCAT-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+        </dependency>
+
+        <!--Apache Commons-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>
+

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseImperativeServiceRestConfig.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseImperativeServiceRestConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@code ServiceRestConfig} class sets common configurations for the service layer.
+ * @author Francois Gutt
+ */
+@ComponentScan(basePackages = "io.americanexpress.synapse.service.imperative")
+@Configuration
+@Import({ApiDocsConfig.class, ExceptionConfig.class, UtilitiesCommonConfig.class})
+public class BaseImperativeServiceRestConfig implements WebMvcConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Constructor taking in objectMapper & metricInterceptor
+     * @param defaultObjectMapper   the default object mapper.
+     */
+    @Autowired
+    public BaseImperativeServiceRestConfig(ObjectMapper defaultObjectMapper) {
+        this.defaultObjectMapper = defaultObjectMapper;
+    }
+
+    /**
+     * Get the JSON message converter.
+     *
+     * @return the JSON message converter.
+     */
+    @Bean
+    public MappingJackson2HttpMessageConverter jsonMessageConverter() {
+        final MappingJackson2HttpMessageConverter messageConverter = new MappingJackson2HttpMessageConverter(getObjectMapper());
+        messageConverter.setSupportedMediaTypes(Collections.singletonList(MediaType.APPLICATION_JSON));
+        return messageConverter;
+    }
+
+    /**
+     * Configure the message converters.
+     *
+     * @param converters message converters of the application.
+     */
+    @Override
+    public void configureMessageConverters(final List<HttpMessageConverter<?>> converters) {
+        converters.add(jsonMessageConverter());
+    }
+
+    /**
+     * Returns default objectMapper.
+     * @return an object mapper
+     */
+    protected ObjectMapper getObjectMapper() {
+        return defaultObjectMapper;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseObservabilityConfig.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseObservabilityConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.config;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * {@code ObservabilityConfig} class sets the configuration setting up Tanzu Wavefront.
+ * The service utilizing this config must set the properties defined in this class configure Tanzu Wavefront.
+ * @author Francois gutt
+ */
+public class BaseObservabilityConfig {
+
+    /**
+     * Environment
+     */
+    private final Environment environment;
+
+    /**
+     * Constructor taking in environment
+     * @param environment environment being wired.
+     */
+    public BaseObservabilityConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Gets Wavefront application name
+     * @return string value of application name for wavefront.
+     */
+    public String getWavefrontApplicationName() {
+        return environment.getRequiredProperty("wavefront.application.name");
+    }
+
+    /**
+     * Gets Wavefront application service
+     * @return string value for service name of application for wavefront.
+     */
+    public String getWavefrontApplicationService() {
+        return environment.getRequiredProperty("wavefront.application.service");
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BasePaginatedServiceRequest.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BasePaginatedServiceRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code BasePaginatedServiceRequest} should be used when pagination is needed in a Poly Controller.
+ */
+public abstract class BasePaginatedServiceRequest extends BaseServiceRequest {
+
+    /**
+     * Used for services that support pagination.
+     */
+    private PageInformation pageInformation;
+
+    /**
+     * Get the pageInformation.
+     *
+     * @return the pageInformation
+     */
+    public PageInformation getPageInformation() {
+        return pageInformation;
+    }
+
+    /**
+     * Set the pageInformation.
+     * @param pageInformation the pageInformation to set
+     */
+    public void setPageInformation(PageInformation pageInformation) {
+        this.pageInformation = pageInformation;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceRequest.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.Map;
+
+/**
+ * {@code BaseServiceRequest} specifies the prototypes for all service requests.
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceRequest {
+
+    /**
+     * The service header map.
+     */
+    private Map<String, String> serviceHeaders;
+
+    /**
+     * Get the service headers map
+     * @return a map of service headers
+     */
+    public Map<String, String> getServiceHeaders() {
+        return serviceHeaders;
+    }
+
+    /**
+     * Sets the service header map.
+     * @param serviceHeaders a mapl of service headers.
+     */
+    public void setServiceHeaders(Map<String, String> serviceHeaders) {
+        this.serviceHeaders = serviceHeaders;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code BaseServiceResponse} specifies the prototypes for all service responses.
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceResponse {
+
+    /**
+     * Id used to uniquely get, update or remove a resource.
+     */
+    protected String id;
+
+    /**
+     * Get the id.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the id.
+     *
+     * @param id the identifier to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+}
+

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ErrorResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ErrorResponse.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+
+/**
+ * {@code ErrorResponse} class is the response model for 4XX and 5XX series errors.
+ *
+ */
+public class ErrorResponse {
+
+    /**
+     * Error code.
+     */
+    private ErrorCode code;
+
+    /**
+     * Friendly header message that gives a brief overview of the error.
+     */
+    private String message;
+
+    /**
+     * Friendly user message to the consumer of the error.
+     */
+    private String moreInfo;
+
+    /**
+     * Message for the developer of the error and possibly a solution to fix the error.
+     */
+    private String developerMessage;
+
+    /**
+     * Argument constructor creates a new instance of ErrorResponse with given values.
+     *
+     * @param code             error code
+     * @param message          friendly header message that gives a brief overview of the error
+     * @param moreInfo         friendly user message to the consumer of the error
+     * @param developerMessage message for the developer of the error and possibly a solution to fix the error
+     */
+    public ErrorResponse(ErrorCode code, String message, String moreInfo, String developerMessage) {
+        this.code = code;
+        this.message = message;
+        this.moreInfo = moreInfo;
+        this.developerMessage = developerMessage;
+    }
+
+    /**
+     * Get the errorCode.
+     *
+     * @return the errorCode
+     */
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    /**
+     * Get the userMessage.
+     *
+     * @return the userMessage
+     */
+    public String getMoreInfo() {
+        return moreInfo;
+    }
+
+    /**
+     * Get the headerMessage.
+     *
+     * @return the headerMessage
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Get the developerMessage.
+     *
+     * @return the developerMessage
+     */
+    public String getDeveloperMessage() {
+        return developerMessage;
+    }
+
+    /**
+     * Set the developerMessage.
+     *
+     * @param developerMessage the developerMessage
+     */
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ExposedHeaders.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ExposedHeaders.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ExposedHeaders} enum has the names of the exposed HTTP headers that can be discovered in addition to the standard response HTTP headers that are exposed by Spring.
+ *
+ * @author Paolo Claudio
+ */
+public enum ExposedHeaders {
+
+    PAGE("Page"), SIZE("Size"), TOTAL_RESULTS_COUNT("Total-Results-Count");
+
+    /**
+     * Name of the exposed header.
+     */
+    private String name;
+
+    /**
+     * Argument constructor creates a new instance of ExposedHeaders with given values.
+     *
+     * @param name of the exposed header
+     */
+    ExposedHeaders(String name) {
+        setName(name);
+    }
+
+    /**
+     * Get the name.
+     *
+     * @return the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageInformation.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageInformation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code PageInformation} class specifies the parameters for a service request,
+ * limiting the results to a subset of how many (size) and on which page (page).
+ *
+ */
+public class PageInformation {
+
+    /**
+     * The page requested of the results.
+     */
+    private int page;
+
+    /**
+     * The number of results per page.
+     */
+    private int size;
+
+    /**
+     * Get the page.
+     *
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     *
+     * @param page the page to set
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * Get the size.
+     *
+     * @return the size
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Set the size.
+     *
+     * @param size the size to set
+     */
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageResponse.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.List;
+
+
+/**
+ * {@code PageResponse} class performs the paging calculation of the results from the service response,
+ * capturing the pages and the results per page.
+ *
+ * @param <O> output type (response type)
+ */
+public class PageResponse<O extends BaseServiceResponse> {
+
+    /**
+     * The default number of results to display per page if none was provided.
+     */
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    /**
+     * Collection received as a response from the service.
+     */
+    private List<O> responses;
+
+    /**
+     * Total number of results from the service.
+     */
+    private int totalResultsCount;
+
+    /**
+     * The number of results per page.
+     */
+    private int pageSize;
+
+    /**
+     * The page index.
+     */
+    private int page;
+
+    /**
+     * The starting range of the results.
+     */
+    private int startingIndex;
+
+    /**
+     * The ending range of the results.
+     */
+    private int endingIndex;
+
+    /**
+     * The maximum number of pages.
+     */
+    private int maxPages;
+
+    /**
+     * Argument constructor creates a new instance of PageResponse with given values.
+     *
+     * @param responses collection received as a response from the service
+     */
+    public PageResponse(List<O> responses) {
+        this.responses = responses;
+    }
+
+    /**
+     * Argument constructor creates a new instance of PageResponse with given values.
+     *
+     * @param responses       collection received as a response from the service
+     * @param pageInformation containing the requested page and size from the request to the service
+     */
+    public PageResponse(List<O> responses, PageInformation pageInformation) {
+        this.responses = responses;
+        this.page = pageInformation.getPage();
+        this.pageSize = pageInformation.getSize();
+        if (pageSize < 0) {
+            pageSize = DEFAULT_PAGE_SIZE;
+        }
+        this.totalResultsCount = responses.size();
+        if (pageSize > this.totalResultsCount) {
+            pageSize = this.totalResultsCount;
+        }
+        calculatePages();
+        setPage(this.page);
+        this.responses = responses.subList(this.startingIndex, this.endingIndex);
+    }
+
+    /**
+     * Get the responses.
+     *
+     * @return the responses
+     */
+    public List<O> getResponses() {
+        return responses;
+    }
+
+    /**
+     * Set the responses.
+     *
+     * @param responses the responses to set
+     */
+    public void setResponses(List<O> responses) {
+        this.responses = responses;
+    }
+
+    /**
+     * Get the totalResultsCount.
+     *
+     * @return the totalResultsCount
+     */
+    public int getTotalResultsCount() {
+        return totalResultsCount;
+    }
+
+    /**
+     * Set the totalResultsCount.
+     *
+     * @param totalResultsCount the totalResultsCount to set
+     */
+    public void setTotalResultsCount(int totalResultsCount) {
+        this.totalResultsCount = totalResultsCount;
+    }
+
+    /**
+     * Get the pageSize.
+     *
+     * @return the pageSize
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Set the pageSize.
+     *
+     * @param pageSize the pageSize to set
+     */
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+        calculatePages();
+    }
+
+    /**
+     * Get the page.
+     *
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     *
+     * @param p the page to set
+     */
+    public void setPage(int p) {
+        if (p >= maxPages) {
+            this.page = maxPages;
+        } else if (p <= 1) {
+            this.page = 1;
+        } else {
+            this.page = p;
+        }
+
+        // Determine where the sublist starts and ends
+        startingIndex = pageSize * (page - 1);
+        if (startingIndex < 0) {
+            startingIndex = 0;
+        }
+
+        endingIndex = startingIndex + pageSize;
+        if (endingIndex > responses.size()) {
+            endingIndex = responses.size();
+        }
+    }
+
+    /**
+     * Gets the maxPages.
+     *
+     * @return the maxPages
+     */
+    public int getMaxPages() {
+        return maxPages;
+    }
+
+    /**
+     * Calculate the number of max pages from the responses.
+     */
+    private void calculatePages() {
+        if (pageSize > 0) {
+            if (responses.size() % pageSize == 0) {
+                maxPages = responses.size() / pageSize;
+            } else {
+                maxPages = (responses.size() / pageSize) + 1;
+            }
+        }
+    }
+
+    /**
+     * Get a subset of all of the responses.
+     *
+     * @return a subset of all of the responses
+     */
+    public List<O> getResponsesForPage() {
+        return responses.subList(startingIndex, endingIndex);
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderKey.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderKey.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ServiceHeaderKey} enum will hold all of the key values for the service headers.
+ *
+ */
+public enum ServiceHeaderKey {
+
+    /**
+     * Authorization.
+     */
+    AUTHORIZATION("Authorization"),
+
+    /**
+     * Client identifier.
+     */
+    CLIENT_ID("Client-ID"),
+
+    /**
+     * Client version.
+     */
+    CLIENT_VERSION("Client-Version"),
+
+    /**
+     * Correlation Identifier Key.
+     */
+    CORRELATION_IDENTIFIER_KEY("Correlation-ID"),
+
+    /**
+     * Use Case Name Key.
+     */
+    USE_CASE_NAME_KEY("Journey-ID");
+
+    /**
+     * Value/name of the enum.
+     */
+    private String value;
+
+    /**
+     * Constructor which sets the default value of the enum.
+     *
+     * @param value actual name of the enum.
+     */
+    ServiceHeaderKey(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the value/name of the enum.
+     *
+     * @return the name of the enum to be returned.
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderValue.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderValue.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ClientHeaderValue} enum is used to house all the header values for the clients.
+ *
+ */
+public enum ServiceHeaderValue {
+
+    /**
+     * Correlation Identifier value.
+     */
+    CORRELATION_IDENTIFIER_VALUE("1234"),
+
+    /**
+     * Client Identifier Value.
+     */
+    CLIENT_IDENTIFIER_VALUE("AppName");
+
+    /**
+     * The value of the enum.
+     */
+    private String value;
+
+    /**
+     * The constructor that sets the default value of the enum.
+     *
+     * @param value value of the enum to set.
+     */
+    ServiceHeaderValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the value of the enum.
+     *
+     * @return the value of the enum to return.
+     */
+    public String getValue() {
+        return value;
+    }
+
+
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaders.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaders.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceHeaders} class contains the header information received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceHeaders {
+
+    /**
+     * Trace elements.
+     */
+    private ServiceTrace trace;
+
+    /**
+     * Routing elements.
+     */
+    private ServiceRouting routing;
+
+    /**
+     * Default constructor creates a new instance of ServiceHeaders with default values.
+     */
+    public ServiceHeaders() {
+        // Fields are set via set methods
+    }
+
+    /**
+     * Get the trace.
+     *
+     * @return the trace
+     */
+    public ServiceTrace getTrace() {
+        return trace;
+    }
+
+    /**
+     * Set the trace.
+     *
+     * @param trace the trace to set
+     */
+    public void setTrace(ServiceTrace trace) {
+        this.trace = trace;
+    }
+
+    /**
+     * Get the routing.
+     *
+     * @return the routing
+     */
+    public ServiceRouting getRouting() {
+        return routing;
+    }
+
+    /**
+     * Set the routing.
+     *
+     * @param routing the routing to set
+     */
+    public void setRouting(ServiceRouting routing) {
+        this.routing = routing;
+    }
+
+    /**
+     * Check to see if another ServiceHeaders object equals this ServiceHeaders object.
+     *
+     * @param o another ServiceHeaders object
+     * @return true if and only if another ServiceHeaders object equals this ServiceHeaders object.
+     */
+    @Override
+    public boolean equals(Object o) {
+
+        if (o == this) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+
+        ServiceHeaders other = (ServiceHeaders) o;
+        return Objects.equals(routing, other.routing)
+                && Objects.equals(trace, other.trace);
+    }
+
+    /**
+     * Return the hash code of this object.
+     *
+     * @return hash code of this object
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(routing, trace);
+    }
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceHeaders{" +
+                "trace=" + trace +
+                ", routing=" + routing +
+                '}';
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeadersFactory.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeadersFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code ServiceHeadersFactory} class produces ServiceHeaders objects.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceHeadersFactory {
+
+    /**
+     * Default constructor.
+     */
+    private ServiceHeadersFactory() {
+    }
+
+    /**
+     * Create a ServiceHeaders object given HTTP headers.
+     *
+     * @param headers containing the HTTP headers
+     * @return the ServiceHeaders object
+     */
+    public static ServiceHeaders create(HttpHeaders headers) {
+        ServiceTrace trace = new ServiceTrace();
+        trace.setCorrelationId(headers.getFirst(ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY.getValue()));
+
+        ServiceRouting routing = new ServiceRouting();
+        ServiceHeaders serviceHeaders = new ServiceHeaders();
+        serviceHeaders.setTrace(trace);
+        serviceHeaders.setRouting(routing);
+
+        return serviceHeaders;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceRouting.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceRouting.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceRouting} class contains the routing elements received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceRouting {
+
+    /**
+     * Client Identifier.
+     */
+    private String clientId;
+
+    /**
+     * Default constructor creates a new instance of ServiceRouting with default values.
+     */
+    public ServiceRouting() {
+
+        // Fields are set via set methods
+    }
+
+
+    /**
+     * Gets the client identifier.
+     *
+     * @return the client identifier.
+     */
+    @ApiModelProperty(value = "Unique client id assigned to the consumer")
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Sets the client identifier.
+     *
+     * @param clientId the client identifier to set.
+     */
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceRouting that = (ServiceRouting) o;
+
+        return Objects.equals(clientId, that.clientId);
+    }
+
+    @Override
+    public int hashCode() {
+        return clientId != null ? clientId.hashCode() : 0;
+    }
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceRouting{" +
+                "clientId='" + clientId + '\'' +
+                '}';
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceTrace.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceTrace.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceTrace} class contains the trace elements received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceTrace {
+
+    /**
+     * Correlation ID.
+     */
+    private String correlationId;
+
+    /**
+     * Default constructor creates a new instance of ServiceTrace with default values.
+     */
+    public ServiceTrace() {
+
+        // Fields are set via set methods
+    }
+
+    /**
+     * Get the correlationId.
+     *
+     * @return the correlationId
+     */
+    @ApiModelProperty(value = "This is a unique identifier used for operational logging purposes")
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    /**
+     * Set the correlationId.
+     *
+     * @param correlationId the correlationId to set
+     */
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceTrace{" +
+                "correlationId='" + correlationId + '\'' +
+                '}';
+    }
+
+    /**
+     * Equals.
+     * @param o an object
+     * @return a boolean
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceTrace that = (ServiceTrace) o;
+
+        return Objects.equals(correlationId, that.correlationId);
+    }
+
+    /**
+     * hashCode.
+     * @return an integer hash
+     */
+    @Override
+    public int hashCode() {
+        return correlationId != null ? correlationId.hashCode() : 0;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseCreateImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseCreateImperativeService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseCreateService} class specifies the prototypes for performing business logic.
+ * @param <I> input request type
+ * @param <O> output response type
+ * @author Francois Gutt
+ */
+public abstract class BaseCreateImperativeService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Add a single resource.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    public O create(org.springframework.http.HttpHeaders headers, I request) {
+        logger.entry(request);
+        final O response = executeCreate(headers, request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for adding a resource.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    protected abstract O executeCreate(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseDeleteImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseDeleteImperativeService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseDeleteService} class specifies the prototypes for performing business logic.
+ * @author Francois Gutt
+ */
+public abstract class BaseDeleteImperativeService extends BaseService {
+
+    /**
+     * Remove a single resource.
+     *
+     * @param headers received from the controller
+     * @param id received from the controller
+     */
+    public void delete(org.springframework.http.HttpHeaders headers, String id) {
+        logger.entry(id);
+        executeDelete(headers, id);
+        logger.exit();
+    }
+
+    /**
+     * Prototype for removing a resource.
+     * @param id body received from the controller
+     */
+    protected abstract void executeDelete(HttpHeaders headers, String id);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetMonoImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetMonoImperativeService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseGetMonoService} class specifies the prototypes for performing business logic.
+ * @param <O> BaseServiceResponse
+ * @author Francois Gutt
+ */
+public abstract class BaseGetMonoImperativeService<O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Gets a single resource.
+     * @param headers received from the controller
+     * @param identifier received from the controller
+     */
+    public O read(org.springframework.http.HttpHeaders headers, String identifier) {
+        logger.entry(identifier);
+        O response = executeRead(headers, identifier);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     * @param headers the http headers
+     * @param identifier the unique identifier
+     * @return a service response
+     */
+    protected abstract O executeRead(HttpHeaders headers, String identifier);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetPolyImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetPolyImperativeService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+public class BaseGetPolyImperativeService {
+
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadMonoImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadMonoImperativeService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseReadMonoService} class specifies the prototypes for performing business logic.
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @param <O> class extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadMonoImperativeService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Get a single resource from the back end service.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return a single resource from the back end service.
+     */
+    public O read(HttpHeaders headers, I request) {
+        logger.entry(request);
+        final O response = executeRead(headers, request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     * @param headers the http header map
+     * @param request the request
+     * @return a read mono response
+     */
+    protected abstract O executeRead(HttpHeaders headers,I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadPolyImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadPolyImperativeService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseReadPolyService} class specifies the prototypes for performing business logic.
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @param <O> class extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadPolyImperativeService <I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Get multiple resources from the back end service.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return a single resource from the back end service.
+     */
+    public Page<O> read(HttpHeaders headers, final I request) {
+        logger.entry(request);
+        final Page<O> responses = executeRead(headers, request);
+        logger.exit(responses);
+        return responses;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     * @param headers the Http header map
+     * @param request a read poly request
+     * @return a page of responses
+     */
+    protected abstract Page<O> executeRead(HttpHeaders headers,I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+
+/**
+ * {@code BaseService} The base service every child controller should extend this parent service.
+ * @author Francois Gutt
+ */
+public abstract class BaseService {
+
+    /**
+     * Logger for the base service.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(getClass());
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseUpdateImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseUpdateImperativeService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseUpdateService} class specifies the prototypes for performing business logic.
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @author Francois Gutt
+ */
+public abstract class BaseUpdateImperativeService<I extends BaseServiceRequest> extends BaseService {
+
+    /**
+     * Update a single resource.
+     *
+     * @param request body received from the controller
+     */
+    public void update(HttpHeaders headers, I request) {
+        logger.entry(request);
+        executeUpdate(headers, request);
+        logger.exit();
+    }
+
+    /**
+     * Prototype for updating a resource.
+     *
+     * @param request body received from the controller
+     */
+    protected abstract void executeUpdate(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-imperative/src/main/resources/banner.txt
+++ b/service/synapse-service-imperative/src/main/resources/banner.txt
@@ -1,0 +1,36 @@
+# Copyright 2020 American Express Travel Related Services Company, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+${Ansi.BLUE}           *##&
+${Ansi.BLUE}        ,########(
+${Ansi.BLUE}        ##########
+${Ansi.BLUE}         ########                 %#(
+${Ansi.BLUE}               #                ######*
+${Ansi.BLUE}                %#              #####(
+${Ansi.BLUE}  ####            #.         @#
+${Ansi.BLUE}%#######           *######/#%
+${Ansi.BLUE} ######* @#####&   ##########
+${Ansi.BLUE}                  ############
+${Ansi.BLUE}                  ###########&
+${Ansi.BLUE}                    %######/     /###/     ######
+${Ansi.BLUE}                        #                *########
+${Ansi.BLUE}                        %(                ########
+${Ansi.BLUE}                         #                  @##@
+${Ansi.BLUE}                         #(
+${Ansi.BLUE}                       /#####
+${Ansi.BLUE}                       #######
+${Ansi.BLUE}                ______     __  __     __   __     ______     ______   ______     ______
+${Ansi.BLUE}               /\  ___\   /\ \_\ \   /\ "-.\ \   /\  __ \   /\  == \ /\  ___\   /\  ___\
+${Ansi.BLUE}               \ \___  \  \ \____ \  \ \ \-.  \  \ \  __ \  \ \  _-/ \ \___  \  \ \  __\
+${Ansi.BLUE}                \/\_____\  \/\_____\  \ \_\\"\_\  \ \_\ \_\  \ \_\    \/\_____\  \ \_____\
+${Ansi.BLUE}                 \/_____/   \/_____/   \/_/ \/_/   \/_/\/_/   \/_/     \/_____/   \/_____/
+${Ansi.BLUE} :: Synapse :: :: Application${application.title} :: ${application.formatted-version} :: Spring Boot${spring-boot.formatted-version} :: ${Ansi.DEFAULT}
+``


### PR DESCRIPTION
# Synapse Service Imperative

## Description

Synapse Service Imperative allows for business logic implementation without the protocol layer therefore leaving the developer free to implement the business logic and making the protocol layer interchangeable.

## Changes in this PR
- config
- models
- services