### PR TITLE
Upgrade Jedis version to a version that is compatible with spring-boot-starter-data-redis 2.7.3

### DIFF
--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -28,6 +28,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.lettuce</groupId>
+                    <artifactId>lettuce-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
@@ -37,7 +43,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.3.0</version>
+            <version>3.8.0</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR contains a fix for synapse-data-redis project. synapse-data-redis contains a dependency for `spring-boot-starter-data-redis:2.7.3 `and a `redis.clients.jedis:3.3.0`. In Spring 2.0, spring-boot-starter-data-redis gives Lettuce dependency by default instead of Jedis. To use Jedis configuration, we need to exlude Lettuce and add compatible Jedis dependency.

https://github.com/spring-projects/spring-boot/issues/9536
