### PR TITLE
feature(synapse-framework-exception): add 429 and 423 error codes

### DIFF
--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ErrorCode.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ErrorCode.java
@@ -58,17 +58,27 @@ public enum ErrorCode {
     /**
      * Used for when the consumer is forbidden to access a resource.
      */
-    AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN, "Forbidden.");
+    AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN, "Forbidden."),
+
+    /**
+     * Used for when the consumer makes too many requests.
+     */
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests."),
+
+    /**
+     * Used for when the consumer makes a request to a locked resource.
+     */
+    LOCKED(HttpStatus.LOCKED, "Locked.");
 
     /**
      * Gets the HttpStatus of the ErrorCode.
      */
-    private HttpStatus httpStatus;
+    private final HttpStatus httpStatus;
 
     /**
      * Gets the message of the ErrorCode.
      */
-    private String message;
+    private final String message;
 
     /**
      * Takes in HttpStatus and a message as a string.
@@ -82,7 +92,7 @@ public enum ErrorCode {
 
     /**
      * Gets HttpStatus.
-     * @return
+     * @return the http status of the error code.
      */
     public HttpStatus getHttpStatus() {
         return httpStatus;
@@ -90,7 +100,7 @@ public enum ErrorCode {
 
     /**
      * Gets message as a String.
-     * @return
+     * @return the message of the error code.
      */
     public String getMessage() {
         return message;

--- a/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ErrorCode.java
+++ b/framework/synapse-framework-exception/src/main/java/io/americanexpress/synapse/framework/exception/model/ErrorCode.java
@@ -73,12 +73,12 @@ public enum ErrorCode {
     /**
      * Gets the HttpStatus of the ErrorCode.
      */
-    private final HttpStatus httpStatus;
+    private HttpStatus httpStatus;
 
     /**
      * Gets the message of the ErrorCode.
      */
-    private final String message;
+    private String message;
 
     /**
      * Takes in HttpStatus and a message as a string.

--- a/framework/synapse-framework-exception/src/main/resources/error-messages.properties
+++ b/framework/synapse-framework-exception/src/main/resources/error-messages.properties
@@ -17,3 +17,5 @@ FORBIDDEN=Your client has issued an forbidden request.
 GENERIC_5XX_ERROR=There was an error. Please try again later.
 MISSING_HTTP_HEADER_ERROR=Missing required HTTP header: {0}.
 AUTHENTICATION_ERROR=Your client does not have permission to get this URL from this server.
+TOO_MANY_REQUESTS=Your client has issued too many requests.
+LOCKED=Your client has issued a request to a locked resource.


### PR DESCRIPTION
This PR adds the HTTP Error codes 429 and 423 to the synapse-framework-exception module.