### PR TITLE
feature(synapse-data-mongodb): implement equals and hashcode

### DIFF
--- a/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/entity/BaseEntity.java
+++ b/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/entity/BaseEntity.java
@@ -23,6 +23,7 @@ import org.springframework.data.annotation.Version;
 
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 /**
  * {@code BaseEntity} class is the parent class for all mongodb documents.
@@ -118,5 +119,19 @@ public abstract class BaseEntity {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof BaseEntity that)) return false;
+        return Objects.equals(identifier, that.identifier) && Objects.equals(createdDateTime, that.createdDateTime) &&
+                Objects.equals(lastModifiedDateTime, that.lastModifiedDateTime) && Objects.equals(createdBy, that.createdBy) &&
+                Objects.equals(lastModifiedBy, that.lastModifiedBy) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, createdDateTime, lastModifiedDateTime, createdBy, lastModifiedBy, version);
     }
 }


### PR DESCRIPTION
This PR implements equals and hashcode methods on the mongo db base entity class.