### PR TITLE
revert: mongodb-driver-sync version to 4.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1002,7 +1002,7 @@
             <dependency>
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongodb-driver-sync</artifactId>
-                <version>4.9.1</version>
+                <version>4.7.2</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Dependabot bumped the mongodb-driver-sync package to 4.9.1 but it's causing issues with the other mongodb packages.
This PR is reverting the change.