### PR TITLE
feat: add get database uri method

### DIFF
--- a/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/config/BaseMongoDBDataConfig.java
+++ b/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/config/BaseMongoDBDataConfig.java
@@ -44,6 +44,10 @@ public abstract class BaseMongoDBDataConfig extends AbstractMongoClientConfigura
         this.environment = environment;
     }
 
+    protected String getDatabaseUri() {
+        return environment.getRequiredProperty("spring.data.mongodb.uri");
+    }
+
     @Override
     protected String getDatabaseName() {
         return environment.getRequiredProperty("spring.data.mongodb.database");
@@ -51,7 +55,7 @@ public abstract class BaseMongoDBDataConfig extends AbstractMongoClientConfigura
 
     @Override
     public MongoClient mongoClient() {
-        ConnectionString connectionString = new ConnectionString(environment.getRequiredProperty("spring.data.mongodb.uri"));
+        ConnectionString connectionString = new ConnectionString(getDatabaseUri());
         MongoClientSettings mongoClientSettings = setMongoClientSettings(connectionString);
         return MongoClients.create(mongoClientSettings);
     }

--- a/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/config/BaseReactiveMongoDBDataConfig.java
+++ b/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/config/BaseReactiveMongoDBDataConfig.java
@@ -42,6 +42,10 @@ public abstract class BaseReactiveMongoDBDataConfig extends AbstractReactiveMong
         this.environment = environment;
     }
 
+    protected String getDatabaseUri() {
+        return environment.getRequiredProperty("spring.data.mongodb.uri");
+    }
+
     @Override
     protected String getDatabaseName() {
         return environment.getRequiredProperty("spring.data.mongodb.database");
@@ -49,7 +53,7 @@ public abstract class BaseReactiveMongoDBDataConfig extends AbstractReactiveMong
 
     @Override
     public MongoClient reactiveMongoClient() {
-        ConnectionString connectionString = new ConnectionString(environment.getRequiredProperty("spring.data.mongodb.uri"));
+        ConnectionString connectionString = new ConnectionString(getDatabaseUri());
         MongoClientSettings mongoClientSettings = setMongoClientSettings(connectionString);
         return this.createReactiveMongoClient(mongoClientSettings);
     }


### PR DESCRIPTION
Adding a getDatabaseUri to the mongo db configs to allow overriding which needs to be done in the case that a module contains more than one mongo database connection