### PR TITLE
feat(base): adding api base modules.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,18 +21,14 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>service</artifactId>
+    <artifactId>api</artifactId>
     <packaging>pom</packaging>
 
     <!--Modules-->
     <modules>
-        <module>service-samples</module>
-        <module>synapse-service-graphql</module>
-        <module>synapse-service-imperative</module>
-        <module>synapse-service-reactive</module>
-        <module>synapse-service-reactive-rest</module>
-        <module>synapse-service-rest</module>
-        <module>synapse-service-test</module>
-    </modules>
 
+        <!-- Base api Synapse dependencies-->
+        <module>synapse-api-rest-imperative</module>
+        <module>synapse-api-rest-reactive</module>
+    </modules>
 </project>

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>api</artifactId>
+        <version>0.3.31-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>synapse-api-rest-imperative</artifactId>
+
+    <!--Dependencies-->
+    <dependencies>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-service-imperative</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-test</artifactId>
+        </dependency>
+
+
+        <!--External Dependencies-->
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+
+        <!--Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+
+
+        <!--Spring Boot-->
+        <dependency>
+            <groupId>org.springframework.plugin</groupId>
+            <artifactId>spring-plugin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!--TOMCAT-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+        </dependency>
+
+        <!--Apache Commons-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/config/BaseApiImperativeRestConfig.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/config/BaseApiImperativeRestConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.api.rest.imperative.interceptor.MetricInterceptor;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.service.imperative.config.BaseImperativeServiceRestConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * {@code ServiceRestConfig} class sets common configurations for the service layer.
+ * @author Francois Gutt
+ */
+@ComponentScan(basePackages = "io.americanexpress.synapse.api.rest.imperative")
+@Configuration
+@Import({ApiDocsConfig.class, BaseImperativeServiceRestConfig.class, ExceptionConfig.class, UtilitiesCommonConfig.class})
+public class BaseApiImperativeRestConfig implements WebMvcConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Default Metric Interceptor.
+     */
+    protected final MetricInterceptor interceptor;
+
+    /**
+     * Constructor taking in objectMapper & metricInterceptor
+     * @param defaultObjectMapper   the default object mapper.
+     * @param interceptor           the metric interceptor.
+     */
+    public BaseApiImperativeRestConfig(ObjectMapper defaultObjectMapper, MetricInterceptor interceptor) {
+        this.defaultObjectMapper = defaultObjectMapper;
+        this.interceptor = interceptor;
+    }
+
+    /**
+     * Adds interceptor to the registry.
+     * @param registry interceptor registry
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor).addPathPatterns("/**");
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseController.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.service.imperative.service.BaseService;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * {@code BaseController} The base controller every child controller should extend this parent controller
+ * @param <S> the service
+ * @author Francois Gutt
+ */
+public class BaseController<S extends BaseService> {
+
+    /**
+     * Service that will be called to get a single resource or multiple resources.
+     */
+    @Autowired
+    protected S service;
+
+    /**
+     * Used for logging.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(this.getClass());
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseCreateImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseCreateImperativeRestController.java
@@ -1,0 +1,39 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.api.rest.imperative.controller.helpers.CreateResponseEntityCreator;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.imperative.service.BaseCreateImperativeService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import javax.validation.Valid;
+
+/**
+ * {@code BaseCreateService} class specifies the prototypes for performing business logic.
+ * @param <I> input request type
+ * @param <O> output response type
+ * @author Francois Gutt
+ */
+public class BaseCreateImperativeRestController<I extends BaseServiceRequest, O extends BaseServiceResponse, S extends BaseCreateImperativeService<I, O>> extends BaseController<S> {
+
+    /**
+     * Create a single resource.
+     * @param headers containing the HTTP headers from the consumer
+     * @param serviceRequest body from the consumer
+     * @return response to the consumer
+     * @author Francois Gutt
+     */
+    @PostMapping
+    @Operation(tags = "Create Operation", summary = "Creates a resource")
+    public ResponseEntity<O> create(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+        O serviceResponse = service.create(headers, serviceRequest);
+        ResponseEntity<O> responseEntity = CreateResponseEntityCreator.create(serviceResponse);
+        logger.exit();
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseDeleteImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseDeleteImperativeRestController.java
@@ -1,0 +1,33 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.service.imperative.service.BaseDeleteImperativeService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * {@code BaseDeleteController} class specifies the prototypes for listening for requests from the consumer
+ * to Delete (DELETE) a resource. This controller expects only one entry per request.
+ * @param <S> service type
+ * @author Gabriel Jimenez
+ */
+public class BaseDeleteImperativeRestController<S extends BaseDeleteImperativeService> extends BaseController<S> {
+
+    /**
+     * Delete a single resource.
+     *
+     * @param headers containing the HTTP headers from the consumer
+     */
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(tags = "Delete Operation", summary = "Deletes a resource")
+    public void delete(@RequestHeader HttpHeaders headers) {
+        logger.entry(headers);
+        service.delete(headers);
+        logger.exit();
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseGetMonoImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseGetMonoImperativeRestController.java
@@ -1,0 +1,38 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.api.rest.imperative.controller.helpers.MonoResponseEntityCreator;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.imperative.service.BaseGetMonoImperativeService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/**
+ * {@code BaseGetMonoImperativeRestController} is base class for read mono controller. This controller handles POST method requests,
+ * but specifically for read purposes.
+ * This controller returns a single object.
+ *
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseGetMonoImperativeService}
+ * @author Francois Gutt
+ */
+public class BaseGetMonoImperativeRestController<O extends BaseServiceResponse, S extends BaseGetMonoImperativeService<O>> extends BaseController<S> {
+
+    /**
+     * Read response entity.
+     * @param headers containing the HTTP headers from the consumer
+     * @return the response entity
+     */
+    @Operation(summary = "Read operation based on path.", description = "Read one resource based on a path variable.")
+    @GetMapping
+    public ResponseEntity<O> read(@RequestHeader HttpHeaders headers) {
+        logger.entry(headers);
+        final O response = service.read(headers);
+        ResponseEntity<O> responseEntity = MonoResponseEntityCreator.create(response);
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadImperativeRestController.java
@@ -1,0 +1,5 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+public class BaseReadImperativeRestController {
+    
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadMonoImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadMonoImperativeRestController.java
@@ -1,0 +1,59 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.api.rest.imperative.controller.helpers.MonoResponseEntityCreator;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.imperative.service.BaseReadMonoImperativeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import javax.validation.Valid;
+
+/**
+ * {@code BaseReadMonoController} class specifies the prototypes for listening for requests from the consumer
+ * to Read (POST) a resource. This Controller expects only one object in request and one object in the
+ * response, hence, "Mono" in the name.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseReadMonoImperativeService}
+ * @author Gabriel Jimenez
+ */
+public class BaseReadMonoImperativeRestController<I extends BaseServiceRequest, O extends BaseServiceResponse, S extends BaseReadMonoImperativeService<I, O>> extends BaseController<S> {
+
+    /**
+     * Constant string for inquiry_results.
+     */
+    public static final String INQUIRY_RESULTS = "/inquiry-results";
+
+    /**
+     * Get a single resource from the back end service.
+     *
+     * @param headers containing the HTTP headers from the consumer
+     * @param serviceRequest body from the consumer
+     * @return a single resource from the back end service
+     */
+    @Operation(tags = "Read Mono Operation", summary = "Read Mono Operation", description = "Reads one resource")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok"),
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+    })
+    @PostMapping(INQUIRY_RESULTS)
+    public ResponseEntity<O> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+
+        final O serviceResponse = service.read(headers, serviceRequest);
+        ResponseEntity<O> responseEntity = MonoResponseEntityCreator.create(serviceResponse);
+
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadPolyImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadPolyImperativeRestController.java
@@ -1,0 +1,63 @@
+package io.americanexpress.synapse.api.rest.imperative.controller;
+
+import io.americanexpress.synapse.api.rest.imperative.controller.helpers.PolyResponseEntityCreator;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.imperative.service.BaseReadPolyImperativeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import java.util.List;
+
+/**
+ * {@code BaseReadPolyController} class specifies the prototypes for listening for requests from the consumer
+ * to Read (POST) a resource. This Controller expects only one object in request and a list of objects as response, hence, "Poly" in the name.
+ *
+ * @param <I> an object extending {@link BaseServiceRequest}
+ * @param <O> an object extending {@link BaseServiceResponse}
+ * @param <S> an object extending {@link BaseReadPolyImperativeService}
+ * @author Gabriel Jimenez
+ */
+public class BaseReadPolyImperativeRestController<I extends BaseServiceRequest, O extends BaseServiceResponse, S extends BaseReadPolyImperativeService<I, O>> extends BaseController<S> {
+
+    /**
+     * Constant string used for multiple_results.
+     */
+    public static final String MULTIPLE_RESULTS = "/multiple-results";
+
+    /**
+     * Get a list of multiple resources from the back end service.
+     *
+     * @param headers               containing the HTTP headers from the consumer
+     * @param serviceRequest        body from the consumer
+     * @param httpServletResponse   HttpServletResponse
+     * @return a list of resources from the back end service
+     */
+    @Operation(summary = "Read operation based on criteria.", description = "Read a collection of resources based on request criteria.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok"),
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+    })
+    @PostMapping(MULTIPLE_RESULTS)
+    public ResponseEntity<List<O>> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest, HttpServletResponse httpServletResponse) {
+        logger.entry(serviceRequest);
+
+        final Page<O> page = service.read(headers, serviceRequest);
+        final ResponseEntity<List<O>> responseEntity = PolyResponseEntityCreator.create(page, httpServletResponse);
+
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.exceptionhandler;
+
+import io.americanexpress.synapse.framework.exception.ApplicationClientException;
+import io.americanexpress.synapse.framework.exception.ApplicationServerException;
+import io.americanexpress.synapse.framework.exception.helper.ErrorMessagePropertyReader;
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import io.americanexpress.synapse.service.imperative.model.ErrorResponse;
+import io.americanexpress.synapse.utilities.common.cryptography.CryptoUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * {@code ControllerExceptionHandler} class handles all the exceptions and errors thrown by the application, excluding Spring Security.
+ * @author Alexei Morgado
+ */
+@RestControllerAdvice
+public class ControllerExceptionHandler {
+
+    /**
+     * Used to log the exceptions.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Used to create the error message based on the error code by reading the value in error-messages.properties.
+     */
+    private final ErrorMessagePropertyReader errorMessagePropertyReader;
+
+    /**
+     * Used to handle input validation errors.
+     */
+    private final InputValidationErrorHandler inputValidationErrorHandler;
+
+    /**
+     * Argument constructor creates a new instance of ControllersExceptionsHandler with given values.
+     * @param errorMessagePropertyReader  used to create the error message based on the error code by reading the value in error-messages.properties
+     * @param inputValidationErrorHandler used to handle input validation errors
+     */
+    public ControllerExceptionHandler(@Autowired ErrorMessagePropertyReader errorMessagePropertyReader, @Autowired InputValidationErrorHandler inputValidationErrorHandler) {
+        this.errorMessagePropertyReader = errorMessagePropertyReader;
+        this.inputValidationErrorHandler = inputValidationErrorHandler;
+    }
+
+    /**
+     * Handle application server exception response entity.
+     * @param applicationServerException the application server exception
+     * @param httpServletRequest         the http servlet request
+     * @return errorResponseEntity of type ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(ApplicationServerException.class)
+    public ResponseEntity<ErrorResponse> handleApplicationServerException(final ApplicationServerException applicationServerException, final HttpServletRequest httpServletRequest) {
+        logger.entry(applicationServerException);
+        final ResponseEntity<ErrorResponse> errorResponseEntity = handleInternalServerError(applicationServerException, httpServletRequest);
+        this.logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+
+    /**
+     * Handle application client exception response entity.
+     * @param applicationClientException the application client exception
+     * @return errorResponseEntity of type ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(ApplicationClientException.class)
+    public ResponseEntity<ErrorResponse> handleApplicationClientException(final ApplicationClientException applicationClientException) {
+        logger.entry(applicationClientException);
+        
+        ResponseEntity<ErrorResponse> errorResponseEntity;
+        
+        if (applicationClientException.getCause() == null) {
+        	ErrorCode errorCode = applicationClientException.getErrorCode();
+            String message = errorMessagePropertyReader.getErrorMessage(errorCode, applicationClientException.getMessageArguments() != null
+                    ? applicationClientException.getMessageArguments() : new String[]{StringUtils.EMPTY});
+            String developerMessage = StringUtils.isNotBlank(applicationClientException.getDeveloperMessage()) ? applicationClientException.getDeveloperMessage() : StringUtils.EMPTY;
+            ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getMessage(), message, developerMessage);
+            errorResponseEntity = ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+        } else {
+        	errorResponseEntity = handleInternalServerError(applicationClientException);
+        }
+        
+        logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+
+    /**
+     * Handle MethodArgumentNotValidExceptions that were thrown by the application due to violations during input validation.
+     * @param methodArgumentNotValidException thrown by the application
+     * @return the error response with HTTP status code 400
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException methodArgumentNotValidException) {
+        logger.warn("Method argument is not valid", methodArgumentNotValidException);
+        ErrorResponse errorResponse = inputValidationErrorHandler.handleInputValidationErrorMessage(methodArgumentNotValidException.getBindingResult());
+        final ResponseEntity<ErrorResponse> errorResponseEntity = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+    
+    /**
+     * Handle BindingExceptions that were thrown by the application due to constraint violations on request models.
+     * @param bindException thrown by the application
+     * @return the error response with HTTP status code 400
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindException(BindException bindException) {
+        logger.warn("Request fields are not valid", bindException);
+        ErrorResponse errorResponse = inputValidationErrorHandler.handleInputValidationErrorMessage(bindException.getBindingResult());
+        ResponseEntity<ErrorResponse> errorResponseEntity = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+
+    /**
+     * Handle HttpMessageNotReadableExceptions due to malformed requests.
+     *
+     * @param httpMessageNotReadableException thrown by the application
+     * @return the error response with HTTP status code 400
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException httpMessageNotReadableException) {
+        logger.warn("HTTP message is not readable", httpMessageNotReadableException);
+        String userMessage = httpMessageNotReadableException.getMessage();
+        ErrorCode errorCode = ErrorCode.GENERIC_4XX_ERROR;
+        final ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getMessage(), userMessage, "Input validation");
+        final ResponseEntity<ErrorResponse> errorResponseEntity = ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+        logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+
+    /**
+     * Handle any Exception or Error not already caught by other exception handler methods in this class.
+     * @param throwable containing the Exception or Error thrown by the application
+     * @return the error response with HTTP status code 500
+     */
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<ErrorResponse> handleThrowable(Throwable throwable) {
+        logger.catching(throwable);
+        final ResponseEntity<ErrorResponse> errorResponseEntity = handleInternalServerError(throwable);
+        logger.exit(errorResponseEntity);
+        return errorResponseEntity;
+    }
+
+    /**
+     * Handle internal server errors.
+     * @param throwable containing the Exception or Error thrown by the application
+     * @return the error response with HTTP status code 500
+     */
+    private ResponseEntity<ErrorResponse> handleInternalServerError(Throwable throwable) {
+        String message = errorMessagePropertyReader.getErrorMessage(ErrorCode.GENERIC_5XX_ERROR);
+        String fullStackTrace = ApplicationServerException.getStackTrace(throwable, System.lineSeparator());
+        ErrorCode errorCode = ErrorCode.GENERIC_5XX_ERROR;
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getMessage(), message, CryptoUtil.encrypt(fullStackTrace));
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
+
+    /**
+     * This method will handle all the internal server errors. Meaning all the 500s family
+     * errors which is when we have an exception in our code and we catch and rethrow it or a
+     * runtime exception is thrown somewhere.
+     *
+     * @param throwable the error that was thrown
+     * @return response of type ResponseEntity<ErrorResponse>
+     */
+    private ResponseEntity<ErrorResponse> handleInternalServerError(final Throwable throwable, final HttpServletRequest httpServletRequest) {
+        logger.catching(throwable);
+        String message = errorMessagePropertyReader.getErrorMessage(ErrorCode.GENERIC_5XX_ERROR);
+        String fullStackTrace = ApplicationServerException.getStackTrace(throwable, System.lineSeparator());
+        ErrorCode  errorCode = ErrorCode.GENERIC_5XX_ERROR;
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getMessage(), message, CryptoUtil.encrypt(fullStackTrace));
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/exceptionhandler/InputValidationErrorHandler.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/exceptionhandler/InputValidationErrorHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.exceptionhandler;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import io.americanexpress.synapse.service.imperative.model.ErrorResponse;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import java.util.StringJoiner;
+
+/**
+ * {@code InputValidationErrorHandler} class creates the error response containing the input validation errors.
+ * @author Alexei Morgado
+ */
+@Component
+public class InputValidationErrorHandler {
+
+    /**
+     * Used to log the input validation error handler.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Create the error response with all of the input violations detected by Hibernate Validator.
+     *
+     * @param bindingResult containing the error messages
+     * @return the error response with HTTP status code 400
+     */
+    public ErrorResponse handleInputValidationErrorMessage(BindingResult bindingResult) {
+        logger.entry(bindingResult);
+
+        // Add all of the error messages separated by commas
+        StringJoiner errorMessageJoiner = new StringJoiner(", ");
+        String defaultErrorMessage;
+        String field;
+        for (final FieldError fieldError : bindingResult.getFieldErrors()) {
+            defaultErrorMessage = fieldError.getDefaultMessage();
+            field = fieldError.getField();
+            if (!field.contains("Valid")) {
+                errorMessageJoiner.add(field + " " + defaultErrorMessage);
+            } else {
+                errorMessageJoiner.add(defaultErrorMessage);
+            }
+        }
+
+        // Create the error response
+        final ErrorResponse errorResponse = new ErrorResponse(ErrorCode.GENERIC_4XX_ERROR,
+                ErrorCode.GENERIC_4XX_ERROR.getMessage(),
+                errorMessageJoiner.toString(),
+                "Input validation");
+
+        logger.exit(errorResponse);
+        return errorResponse;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/healthcheck/HealthCheckController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/healthcheck/HealthCheckController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.healthcheck;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * {@code HealthCheckController} class specifies health check endpoint URIs to ensure that requests are being received by the application.
+ * @author Paolo Claudio
+ */
+@RestController
+public class HealthCheckController {
+
+    /**
+     * The health check endpoint.
+     */
+    public static final String HEALTH_CHECK_ENDPOINT = "/health";
+
+    /**
+     * The health global Geographically Distributed High Availability (gdha) check endpoint.
+     */
+    public static final String HEALTH_CHECK__GDHA_ENDPOINT = "/health-gdha";
+
+    /**
+     * Health message used for the health check URIs.
+     */
+    static String HEALTH_MESSAGE = "App is healthy!";
+
+    /**
+     * Default health check URI used by all services.
+     * @return a constant message to notify that the service is receiving a request
+     */
+    @GetMapping(HEALTH_CHECK_ENDPOINT)
+    public String healthCheck() {
+        return HEALTH_MESSAGE;
+    }
+
+    /**
+     * Default health check URI used by all services.
+     *
+     * @return a constant message to notify that the service is receiving a request
+     */
+    @GetMapping(HEALTH_CHECK__GDHA_ENDPOINT)
+    public String healthGdhaCheck() {
+        return HEALTH_MESSAGE;
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/CreateResponseEntityCreator.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/CreateResponseEntityCreator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.helpers;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import java.net.URI;
+
+/**
+ * {@code CreateResponseEntityCreator} Helps creates ResponseEntity.
+ * @param <O> BaseServiceResponse will be used for the response object.
+ *
+ * @author Francois Gutt
+ */
+public class CreateResponseEntityCreator<O extends BaseServiceResponse> {
+
+    /**
+     * Create the POST response entity by specifying the creation location in the HTTP headers.
+     * @param serviceResponse body to set in the response entity.
+     * @return the POST response entity.
+     */
+    public static <O extends BaseServiceResponse> ResponseEntity<O> create(O serviceResponse) {
+
+        // Default URI location in case the response identifier is null
+        String responseId = "0";
+
+        if (serviceResponse != null) {
+            String id = serviceResponse.getId();
+            if (StringUtils.isNotBlank(id)) {
+                responseId = id.trim();
+            }
+        }
+
+        // Build the resource location to specify in the response
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{identifier}")
+                .buildAndExpand(responseId)
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/MonoResponseEntityCreator.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/MonoResponseEntityCreator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.helpers;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * {@code MonoResponseEntityCreator} Creates ResponseEntity for mono response.
+ * @param <O> BaseServiceResponse will be used for the response object.
+ *
+ * @author Francois Gutt
+ */
+public class MonoResponseEntityCreator<O extends BaseServiceResponse> {
+
+    /**
+     * Creates a response entity.
+     * @param serviceResponse service response.
+     * @return response entity.
+     * @param <O> an object extending {@link BaseServiceResponse}.
+     */
+    public static <O extends BaseServiceResponse> ResponseEntity<O> create(O serviceResponse) {
+        return serviceResponse == null ? new ResponseEntity<>(HttpStatus.NO_CONTENT) : ResponseEntity.ok(serviceResponse);
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/PolyResponseEntityCreator.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/helpers/PolyResponseEntityCreator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.controller.helpers;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+/**
+ * {@code PolyResponseEntityCreator} creates ResponseEntity for poly responses.
+ * @param <O> a response extending {@link BaseServiceResponse}
+ *
+ * @author Francois Gutt
+ */
+public class PolyResponseEntityCreator<O extends BaseServiceResponse> {
+
+    /**
+     * Creates a Poly ResponseEntity with pagination.
+     * @param page will be used for pagination.
+     * @param httpServletResponse response from the service.
+     * @return ResponseEntity that will have {@link BaseServiceResponse}
+     */
+    public static <O extends BaseServiceResponse> ResponseEntity<List<O>> create(Page<O> page, HttpServletResponse httpServletResponse) {
+        final ResponseEntity<List<O>> responseEntity;
+        List<O> pageContent = null;
+        if (page != null) {
+            pageContent = page.getContent();
+        }
+        if (page == null || CollectionUtils.isEmpty(pageContent)) {
+            responseEntity = new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            setHeadersInResponse(page, httpServletResponse);
+            responseEntity = new ResponseEntity<>(pageContent, HttpStatus.OK);
+        }
+        return responseEntity;
+    }
+
+    /**
+     * Creates pagination header
+     * @param page pagination
+     * @param httpServletResponse response
+     */
+    private static <O extends BaseServiceResponse> void setHeadersInResponse(final Page<O> page, final HttpServletResponse httpServletResponse) {
+        if (page != null && !CollectionUtils.isEmpty(page.getContent())) {
+            httpServletResponse.setHeader("size", String.valueOf(page.getSize()));
+            httpServletResponse.setHeader("page", String.valueOf(page.getNumber()));
+            httpServletResponse.setHeader("total_results_count", String.valueOf(page.getNumberOfElements()));
+        }
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.interceptor;
+
+import io.americanexpress.synapse.framework.exception.ApplicationClientException;
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import static io.americanexpress.synapse.service.imperative.model.ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY;
+import static io.americanexpress.synapse.service.imperative.model.ServiceHeaderKey.USE_CASE_NAME_KEY;
+
+/**
+ * {@code BaseHttpInterceptor} class specifies the prototypes for performing HTTP header validations for a service.
+ * @author Paolo Claudio
+ */
+public abstract class BaseHttpInterceptor implements HandlerInterceptor {
+
+    /**
+     * Used to log the HTTP headers.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Required HTTP header names.
+     */
+    protected Collection<String> requiredHttpHeaderNames = new ArrayList<>(Arrays.asList(HttpHeaders.CONTENT_TYPE, CORRELATION_IDENTIFIER_KEY.getValue(), USE_CASE_NAME_KEY.getValue()));
+
+    /**
+     * Validate the required HTTP headers.
+     *
+     * @param request  containing the request of the service that has the HTTP headers
+     * @param response containing the response of the service
+     * @param handler  used for the interceptor
+     * @return a boolean
+     * @throws Exception whenever an issue occurs during the prehandling of this request
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        logger.entry(request, response, handler);
+
+        // If any of the required HTTP headers are missing, this request is invalid
+        String httpHeaderValue;
+        for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
+            httpHeaderValue = request.getHeader(requiredHttpHeaderName);
+            if (httpHeaderValue == null) {
+                throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.", ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+            }
+        }
+
+        // HTTP header validation is successful
+        logger.exit();
+        return true;
+    }
+
+    /**
+     * Get the required HTTP header names to be validated.
+     *
+     * @return the required HTTP header names
+     */
+    protected List<String> getRequiredHttpHeaderNames() {
+        // Note: it is possible that a service needs no request HTTP header validation
+        // Should a service require request HTTP header validation, then override this method
+        return new ArrayList<>();
+    }
+}

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/MetricInterceptor.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/MetricInterceptor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.imperative.interceptor;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import static io.americanexpress.synapse.service.imperative.model.ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY;
+
+/**
+ * {@code MetricInterceptor} class captures metrics about Synapse such as logging API response times.<br>
+ * <strong>Example:</strong> RESPONSE TIME: The request 0cfcb89d-0d50-4d4c-889d-083cb817b547 POST: /path/to/api with status 400 took 424 milliseconds.
+ * @author Alexei Morgado
+ */
+@Component
+public class MetricInterceptor implements HandlerInterceptor {
+
+    /**
+     * Used to log the metrics.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Request identifier.
+     */
+    private final String REQUEST_ID = "requestId";
+
+    /**
+     * start time.s
+     */
+    private final String START_TIME = "startTime";
+
+    /**
+     * Capture the request information.
+     * @param request  current HTTP request
+     * @param response current HTTP response
+     * @param handler  chosen handler to execute, for type and/or instance evaluation
+     * @return true if the execution chain should proceed with the next interceptor or the handler itself;
+     * else, DispatcherServlet assumes that this interceptor has already dealt with the response itself
+     * @throws Exception in case of errors
+     */
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String correlationId = request.getHeader(CORRELATION_IDENTIFIER_KEY.getValue());
+        logger.info("APPLICATION_METRICS REQUEST ID={}, CORRELATION_ID={}, HOST={}, HTTP_METHOD={}, URI={}",
+                requestId,
+                correlationId,
+                request.getHeader("host"),
+                request.getMethod(),
+                request.getRequestURI()
+        );
+        long startTime = System.currentTimeMillis();
+        request.setAttribute(START_TIME, startTime);
+        request.setAttribute(REQUEST_ID, requestId);
+        return true;
+    }
+
+    /**
+     * Capture the response information.
+     * @param request   current HTTP request
+     * @param response  current HTTP response
+     * @param handler   the handler (or HandlerMethod) that started asynchronous execution, for type and/or instance examination
+     * @param exception any exception thrown on handler execution, if any; this does not include exceptions that have been handled through an exception resolver
+     * @throws Exception in case of errors
+     */
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception exception) throws Exception {
+        long startTime = (Long) request.getAttribute(START_TIME);
+        long endTime = System.currentTimeMillis();
+        long executeTime = endTime - startTime;
+        int status = (response).getStatus();
+        String correlationId = response.getHeader(CORRELATION_IDENTIFIER_KEY.getValue());
+        logger.info("APPLICATION_METRICS RESPONSE TIME: REQUEST_ID={}, CORRELATION_ID={}, HTTP_METHOD={}, URI={}, STATUS={}, TIME={} milliseconds.",
+                request.getAttribute(REQUEST_ID),
+                correlationId,
+                request.getMethod(),
+                request.getRequestURI(),
+                status,
+                executeTime
+        );
+    }
+}

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>api</artifactId>
+        <version>0.3.31-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>synapse-api-rest-reactive</artifactId>
+
+    <!--Dependencies-->
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-service-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+
+        <!--Spring-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/config/BaseApiReactiveRestConfig.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/config/BaseApiReactiveRestConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.service.reactive.config.BaseReactiveServiceRestConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+/**
+ * {@code BaseServiceReactiveRestConfig} sets common configurations for the service layer.
+ *
+ * @author Francois Gutt
+ */
+@ComponentScan(basePackages = "io.americanexpress.synapse.api.rest.reactive")
+@Configuration
+@EnableWebFlux
+@Import({BaseReactiveServiceRestConfig.class, ExceptionConfig.class, ApiDocsConfig.class, UtilitiesCommonConfig.class})
+public class BaseApiReactiveRestConfig implements WebFluxConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Constructor taking in objectMapper.
+     * @param defaultObjectMapper   the default object mapper.
+     */
+    @Autowired
+    public BaseApiReactiveRestConfig(ObjectMapper defaultObjectMapper) {
+        this.defaultObjectMapper = defaultObjectMapper;
+    }
+
+    /**
+     * Returns default objectMapper.
+     * @return an object mapper
+     */
+    protected ObjectMapper getObjectMapper() {
+        return defaultObjectMapper;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.service.reactive.service.BaseService;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * {@code BaseController} The base controller every child controller should extend this parent controller
+ * @param <S> an object extending the {@link BaseService}
+ *
+ * @author Francois gutt
+ */
+public class BaseController<S extends BaseService> {
+
+    /**
+     * Service that will be called to get a single resource or multiple resources.
+     */
+    @Autowired
+    protected S service;
+
+    /**
+     * Used for logging.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(this.getClass());
+
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseCreateReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseCreateReactiveRestController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.api.rest.reactive.controller.helper.MonoResponseEntityCreator;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.reactive.service.BaseCreateReactiveService;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import javax.validation.Valid;
+
+/**
+ * {@code BaseCreateReactiveRestController} class specifies the prototypes for listening for requests from the consumer
+ * to Create (POST), Update (PUT/PATCH) or Delete (DELETE) a resource.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseCreateReactiveService}
+ * @author Gabriel Jimenez
+ */
+@RestController
+public class BaseCreateReactiveRestController<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse,
+            S extends BaseCreateReactiveService<I, O>
+        > extends BaseController<S> {
+
+    /**
+     * Create a single resource.
+     *
+     * @param headers the headers
+     * @param serviceRequest body from the consumer
+     * @return response to the consumer
+     */
+    @PostMapping
+    @Operation(tags = "Reactive Create Operation", summary = "Creates a reactive resource")
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "Created"),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+    })
+    public ResponseEntity<Mono<O>> create(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+        final var serviceResponse = service.create(serviceRequest);
+        ResponseEntity<Mono<O>> responseEntity = MonoResponseEntityCreator.create(serviceResponse);
+        logger.exit();
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseDeleteReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseDeleteReactiveRestController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.service.BaseDeleteReactiveService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseDeleteReactiveRestController} is base class for delete mono controller. This controller handles DELETE
+ *  method requests, but specifically for delete purposes.
+ *  This controller returns a single object.
+ * @param <S> an object extending the {@link BaseDeleteReactiveService}
+ * @author Francois Gutt
+ */
+public class BaseDeleteReactiveRestController<
+            I extends BaseServiceRequest,
+            S extends BaseDeleteReactiveService
+        > extends BaseController<S> {
+
+    /**
+     * Delete a single resource.
+     * @param headers the headers
+     * @param serviceRequest of the resource to be deleted
+     */
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(tags = "Delete Operation", summary = "Deletes a resource reactively")
+    public Mono<ResponseEntity<Void>> delete(@RequestHeader HttpHeaders headers, @PathVariable I serviceRequest) {
+        logger.entry(serviceRequest);
+        var serviceResults = service.delete(serviceRequest);
+        var responseEntity = serviceResults
+                .map(res -> new ResponseEntity<Void>(HttpStatus.NO_CONTENT));
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseGetFluxReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseGetFluxReactiveRestController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.reactive.service.BaseGetFluxReactiveService;
+import io.americanexpress.synapse.service.reactive.service.BaseGetMonoReactiveService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@code BaseGetFluxReactiveRestController} is base class for read mono controller.
+ * This controller handles GET method requests, but specifically for read purposes.
+ *  This controller returns a single object.
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseGetMonoReactiveService}
+ * @author Francois Gutt
+ */
+public class BaseGetFluxReactiveRestController<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse,
+            S extends BaseGetFluxReactiveService<I,O>
+        >
+        extends BaseController<S> {
+
+    /**
+     * Get a list of multiple resources from the back end service.
+     * @param headers the headers
+     * @return response
+     */
+    @ApiOperation(value = "Reactive get flux", notes = "Gets all resources reactively")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Ok"),
+            @ApiResponse(code = 204, message = "No Content"),
+            @ApiResponse(code = 206, message = "Partial Content"),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+    })
+    @GetMapping()
+    public Flux<O> read(@RequestHeader HttpHeaders headers, I serviceRequest) {
+        logger.entry();
+        final var serviceResponse = service.read(serviceRequest);
+        logger.exit();
+        return serviceResponse;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseGetMonoReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseGetMonoReactiveRestController.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.api.rest.reactive.controller.helper.MonoResponseEntityCreator;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.reactive.service.BaseGetMonoReactiveService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Mono;
+import javax.validation.Valid;
+
+/**
+ * {@code BaseGetMonoReactiveRestController} is base class for read mono controller.
+ * This controller handles GET method requests, but specifically for read purposes.
+ *  This controller returns a single object.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseGetMonoReactiveService}
+ * @author Francois Gutt
+ */
+public class BaseGetMonoReactiveRestController<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse,
+            S extends BaseGetMonoReactiveService<I, O>
+        > extends BaseController<S> {
+
+    /**
+     * Get a single resource from the back end service.
+     *
+     * @param headers the headers
+     * @param  serviceRequest the service request
+     * @return response
+     */
+    @ApiOperation(value = "Reactive get mono", notes = "Gets one resource reactively")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Ok"),
+            @ApiResponse(code = 204, message = "No Content"),
+            @ApiResponse(code = 206, message = "Partial Content"),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+    })
+    @GetMapping
+    public ResponseEntity<Mono<O>> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+        final var serviceResponse = service.read(serviceRequest);
+        ResponseEntity<Mono<O>> responseEntity = MonoResponseEntityCreator.create(serviceResponse);
+        logger.exit();
+        return responseEntity;
+    }
+
+//    @GetMapping
+//    public Mono<ResponseEntity<O>> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+//        logger.entry(serviceRequest);
+//        var serviceResponse = service.read(serviceRequest);
+//        var responseEntity = serviceResponse
+//                .map(ResponseEntity::ok)
+//                .defaultIfEmpty(ResponseEntity.noContent().build());
+//        logger.exit(responseEntity);
+//        return responseEntity;
+//    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseReadFluxReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseReadFluxReactiveRestController.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.reactive.service.BaseReadFluxReactiveService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Flux;
+import javax.validation.Valid;
+
+/**
+ * {@code BaseReadFluxReactiveRestController} class specifies the prototypes for listening for requests from the consumer
+ * to Read (POST) a resource.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseReadFluxReactiveService}
+ * @author Gabriel Jimenez
+ */
+public class BaseReadFluxReactiveRestController<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse,
+            S extends BaseReadFluxReactiveService<I, O>
+        > extends BaseController<S> {
+
+    /**
+     * The constant MULTIPLE_RESULTS.
+     */
+    public static final String MULTIPLE_RESULTS = "/multiple-results";
+
+    /**
+     * Get a list of multiple resources from the back end service.
+     * @param headers the headers
+     * @param serviceRequest body from the consumer
+     * @return a list of resources from the back end service
+     */
+    @ApiOperation(value = "Reactive Read Poly", notes = "Gets a collection of resources", response = ResponseEntity.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Ok"),
+            @ApiResponse(code = 204, message = "No Content"),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+    })
+    @PostMapping(MULTIPLE_RESULTS)
+    public Flux<ResponseEntity<O>> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+        final var serviceResult = service.read(serviceRequest);
+        final var responseEntity = serviceResult
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.noContent().build());
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseReadMonoReactiveRestController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/BaseReadMonoReactiveRestController.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import io.americanexpress.synapse.service.reactive.service.BaseReadMonoReactiveService;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Mono;
+import javax.validation.Valid;
+
+/**
+ * {@code BaseReadMonoReactiveRestController} class specifies the prototypes for listening for requests from the consumer
+ * to Read (POST) a resource. This Controller expects only one object in request and one object in the
+ * response, hence, "Mono" in the name.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @param <S> an object extending the {@link BaseReadMonoReactiveService}
+ * @author Gabriel Jimenez
+ */
+public class BaseReadMonoReactiveRestController<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse,
+            S extends BaseReadMonoReactiveService<I, O>
+        > extends BaseController<S> {
+
+    /**
+     * The constant INQUIRY_RESULTS.
+     */
+    public static final String INQUIRY_RESULTS = "/inquiry-results";
+
+    /**
+     * Get a single resource from the back end service.
+     * @param headers the headers
+     * @param serviceRequest body from the consumer
+     * @return a single resource from the back end service
+     */
+    @ApiOperation(value = "Reactive Read Mono", notes = "Gets one resource")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Ok"),
+            @ApiResponse(code = 204, message = "No Content"),
+            @ApiResponse(code = 206, message = "Partial Content"),
+            @ApiResponse(code = 400, message = "Bad Request"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+    })
+    @PostMapping(INQUIRY_RESULTS)
+    public Mono<ResponseEntity<O>> read(@RequestHeader HttpHeaders headers, @Valid @RequestBody I serviceRequest) {
+        logger.entry(serviceRequest);
+        var serviceResponse = service.read(serviceRequest);
+        var responseEntity = serviceResponse
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.noContent().build());
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/exceptionhandler/ControllerExceptionHandler.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/exceptionhandler/ControllerExceptionHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller.exceptionhandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.exception.ApplicationClientException;
+import io.americanexpress.synapse.framework.exception.ApplicationServerException;
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import io.americanexpress.synapse.service.reactive.model.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.server.WebExceptionHandler;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code ControllerExceptionHandler} handles all the exceptions and errors thrown by the application.
+ * The order is -2 to capture exceptions from other filters.
+ * @author Wendy Hu
+ */
+@Component
+@Order(-2)
+@RequiredArgsConstructor
+public class ControllerExceptionHandler implements WebExceptionHandler {
+
+    /**
+     * Logs exceptions.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Handles input validation errors.
+     */
+    private final InputValidationErrorHandler inputValidationErrorHandler;
+
+    /**
+     * Handles application exceptions.
+     * @param exchange the server web exchange
+     * @param throwable the throwable exception
+     * @return a mono void
+     */
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable throwable) {
+        ErrorResponse errorResponse = null;
+
+        if (throwable instanceof WebExchangeBindException webExchangeBindException) {
+            exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+            errorResponse = inputValidationErrorHandler.handleInputValidationErrorMessage(webExchangeBindException);
+        } else if (throwable instanceof ServerWebInputException serverWebInputException) {
+            exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+            errorResponse = new ErrorResponse(ErrorCode.GENERIC_4XX_ERROR, serverWebInputException.getMessage(), throwable.getMessage(), serverWebInputException.getLocalizedMessage());
+        } else if (throwable instanceof ApplicationClientException applicationClientException) {
+            exchange.getResponse().setStatusCode(applicationClientException.getErrorCode().getHttpStatus());
+            errorResponse = new ErrorResponse(applicationClientException.getErrorCode(), applicationClientException.getErrorCode().getMessage(),
+                    throwable.getMessage(), applicationClientException.getDeveloperMessage());
+        } else if (throwable instanceof ApplicationServerException) {
+            errorResponse = handleInternalServerError(throwable);
+        } else {
+            errorResponse = handleInternalServerError(throwable);
+        }
+
+        return createResponseBody(exchange, errorResponse);
+    }
+
+    /**
+     * Creates the response body with the error response.
+     * @param exchange the server web exchange
+     * @param errorResponse the error response
+     * @return a mono void
+     */
+    public Mono<Void> createResponseBody(ServerWebExchange exchange, ErrorResponse errorResponse) {
+        DataBuffer buffer;
+        try {
+            buffer = exchange.getResponse().bufferFactory().wrap(new ObjectMapper().writeValueAsBytes(errorResponse));
+        } catch (JsonProcessingException exception) {
+            throw new ApplicationServerException(exception);
+        }
+
+        exchange.getResponse().setStatusCode(errorResponse.getCode().getHttpStatus());
+        exchange.getResponse().getHeaders().add("Content-Type", "application/json");
+        return exchange.getResponse().writeWith(Flux.just(buffer));
+    }
+
+    /**
+     * Handles internal server errors.
+     * @param throwable the throwable exception
+     * @return the error response
+     */
+    public ErrorResponse handleInternalServerError(Throwable throwable) {
+        logger.warn("Error", throwable);
+        return new ErrorResponse(ErrorCode.GENERIC_5XX_ERROR, ErrorCode.GENERIC_5XX_ERROR.getMessage(), throwable.getMessage(),
+                ApplicationServerException.getStackTrace(throwable, System.lineSeparator()));
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/exceptionhandler/InputValidationErrorHandler.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/exceptionhandler/InputValidationErrorHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller.exceptionhandler;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import io.americanexpress.synapse.service.reactive.model.ErrorResponse;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import java.util.StringJoiner;
+
+/**
+ * {@code InputValidationErrorHandler} creates the error response containing the input validation errors.
+ *
+ * @author Wendy Hu
+ */
+@Component
+public class InputValidationErrorHandler {
+
+    /**
+     * Logs exceptions.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Handles input validation errors.
+     * @param exception the exception
+     * @return the error response
+     */
+    public ErrorResponse handleInputValidationErrorMessage(WebExchangeBindException exception) {
+        logger.entry(exception);
+
+        // Add all error messages separated by commas
+        StringJoiner errorMessageJoiner = new StringJoiner(", ");
+        String defaultErrorMessage;
+        String field;
+        for (final FieldError fieldError : exception.getFieldErrors()) {
+            defaultErrorMessage = fieldError.getDefaultMessage();
+            field = fieldError.getField();
+            if (!field.contains("Valid")) {
+                errorMessageJoiner.add(field + " " + defaultErrorMessage);
+            } else {
+                errorMessageJoiner.add(defaultErrorMessage);
+            }
+        }
+
+        // Create the error response
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.GENERIC_4XX_ERROR,
+                ErrorCode.GENERIC_4XX_ERROR.getMessage(),
+                errorMessageJoiner.toString(),
+                "Input validation");
+
+        logger.exit(errorResponse);
+        return errorResponse;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/healthcheck/HealthCheckController.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/healthcheck/HealthCheckController.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller.healthcheck;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code HealthCheckController} class specifies health check endpoint URIs to ensure that requests are being received by the application.
+ *
+ * @author Paolo Claudio
+ */
+@RestController
+public class HealthCheckController {
+
+    /**
+     * The health check endpoint.
+     */
+    public static final String HEALTH_CHECK_ENDPOINT = "/health";
+
+    /**
+     * The health global Geographically Distributed High Availability (gdha) check endpoint.
+     */
+    public static final String HEALTH_GDHA_CHECK_ENDPOINT = "/health-gdha";
+
+    /**
+     * Health message used for the health check URIs.
+     */
+    static String HEALTH_MESSAGE = "App is healthy!";
+
+    /**
+     * Default health check URI used by all services.
+     *
+     * @return a constant message to notify that the service is receiving a request
+     */
+    @GetMapping(HEALTH_CHECK_ENDPOINT)
+    public Mono<String> healthCheck() {
+        return Mono.just(HEALTH_MESSAGE);
+    }
+
+    /**
+     * Default health check URI used by all services.
+     *
+     * @return a constant message to notify that the service is receiving a request
+     */
+    @GetMapping(HEALTH_GDHA_CHECK_ENDPOINT)
+    public Mono<String> healthGdhaCheck() {
+        return Mono.just(HEALTH_MESSAGE);
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/helper/MonoResponseEntityCreator.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/controller/helper/MonoResponseEntityCreator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.controller.helper;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code MonoResponseEntityCreator} Creates ResponseEntity for mono response.
+ * @param <O> BaseServiceResponse will be used for the response object.
+ *
+ * @author Francois Gutt
+ */
+public class MonoResponseEntityCreator<O extends BaseServiceResponse> {
+
+    /**
+     * Creates a response entity.
+     *
+     * @param serviceResponse service response.
+     * @return response entity.
+     * @param <O> an object extending {@link BaseServiceResponse}.
+     */
+    public static <O extends BaseServiceResponse> ResponseEntity<Mono<O>> create(Mono<O> serviceResponse) {
+        return serviceResponse == null ? new ResponseEntity<>(HttpStatus.NO_CONTENT) : ResponseEntity.ok(serviceResponse);
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/filter/BaseHttpHeadersFilter.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/filter/BaseHttpHeadersFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.filter;
+
+import io.americanexpress.synapse.framework.exception.ApplicationClientException;
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code BaseHttpHeadersFilter} performs HTTP headers validation.
+ * @author Wendy Hu
+ */
+@Component
+public abstract class BaseHttpHeadersFilter implements WebFilter {
+
+    /**
+     * Used for logging.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Intercepts the request to check the headers.
+     *
+     * @param exchange the server web exchange
+     * @param chain the web filter chain
+     * @return a void mono
+     */
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        logger.entry(exchange.getRequest(), exchange.getResponse());
+
+        if(!shouldNotFilter(exchange.getRequest())) {
+            // If any of the required HTTP headers are missing, this request is invalid
+            String httpHeaderValue;
+            for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
+                httpHeaderValue = exchange.getRequest().getHeaders().getFirst(requiredHttpHeaderName);
+                if (httpHeaderValue == null) {
+                    throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.",
+                            ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+                }
+            }
+        }
+
+        // HTTP header validation is successful
+        logger.exit();
+        return chain.filter(exchange);
+    }
+
+    /**
+     * Get the required HTTP header names to be validated.
+     *
+     * @return the required HTTP header names
+     */
+    protected List<String> getRequiredHttpHeaderNames() {
+        // Note: it is possible that a service needs no request HTTP header validation
+        // Should a service require request HTTP header validation, then override this method
+        return new ArrayList<>();
+    }
+
+    /**
+     * Subclasses can override this method to control what requests should not be filtered.
+     * for example override the method with the following to prevent
+     * health endpoint : return request.getURI().getPath().equals("/health")
+     *
+     * @param request the incoming request
+     * @return true if url should not be filtered
+     */
+    protected boolean shouldNotFilter(ServerHttpRequest request) {
+        return false;
+    }
+}

--- a/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/filter/BaseMetricsFilter.java
+++ b/api/synapse-api-rest-reactive/src/main/java/io/americanexpress/synapse/api/rest/reactive/filter/BaseMetricsFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.api.rest.reactive.filter;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseMetricsFilter} captures metrics about the request such as the response time.
+ *
+ * @author Elisha Aquino
+ */
+@Component
+public abstract class BaseMetricsFilter implements WebFilter {
+
+    /**
+     * Used to log the metrics.
+     */
+    private final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+    /**
+     * Captures metrics for the request.
+     *
+     * @param exchange the server web exchange
+     * @param chain the web filter chain
+     * @return a void mono
+     */
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        long startTime = System.currentTimeMillis();
+        return chain.filter(exchange).doFinally(signalType -> {
+            long totalTime = System.currentTimeMillis() - startTime;
+            ServerHttpRequest request = exchange.getRequest();
+            logger.info("APPLICATION_METRICS RESPONSE_TIME={}, URI={}, STATUS={}",
+                    totalTime, request.getPath(), exchange.getResponse().getStatusCode());
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     </properties>
 
     <modules>
+        <module>api</module>
         <module>archetype</module>
         <module>framework</module>
         <module>service</module>
@@ -212,10 +213,33 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- Api -->
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-api-rest-imperative</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-api-rest-reactive</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!--Service-->
             <dependency>
                 <groupId>io.americanexpress.synapse</groupId>
                 <artifactId>synapse-service-graphql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-service-imperative</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>synapse-service-reactive</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service</artifactId>
+        <version>0.3.31-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>synapse-service-imperative</artifactId>
+
+    <!--Dependencies-->
+    <dependencies>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-exception</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-test</artifactId>
+        </dependency>
+
+
+        <!--External Dependencies-->
+        <!-- JUnit -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+
+        <!--Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+
+
+        <!--Spring Boot-->
+        <dependency>
+            <groupId>org.springframework.plugin</groupId>
+            <artifactId>spring-plugin-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!--TOMCAT-->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+        </dependency>
+
+        <!--Apache Commons-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseImperativeServiceRestConfig.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseImperativeServiceRestConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@code ServiceRestConfig} class sets common configurations for the service layer.
+ *
+ * @author Francois Gutt
+ */
+@ComponentScan(basePackages = "io.americanexpress.synapse.service.imperative")
+@Configuration
+@Import({ApiDocsConfig.class, ExceptionConfig.class, UtilitiesCommonConfig.class})
+public class BaseImperativeServiceRestConfig implements WebMvcConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Constructor taking in objectMapper & metricInterceptor.
+     *
+     * @param defaultObjectMapper   the default object mapper
+     */
+    @Autowired
+    public BaseImperativeServiceRestConfig(ObjectMapper defaultObjectMapper) {
+        this.defaultObjectMapper = defaultObjectMapper;
+    }
+
+    /**
+     * Get the JSON message converter.
+     *
+     * @return the JSON message converter
+     */
+    @Bean
+    public MappingJackson2HttpMessageConverter jsonMessageConverter() {
+        final MappingJackson2HttpMessageConverter messageConverter = new MappingJackson2HttpMessageConverter(getObjectMapper());
+        messageConverter.setSupportedMediaTypes(Collections.singletonList(MediaType.APPLICATION_JSON));
+        return messageConverter;
+    }
+
+    /**
+     * Configure the message converters.
+     *
+     * @param converters message converters of the application.
+     */
+    @Override
+    public void configureMessageConverters(final List<HttpMessageConverter<?>> converters) {
+        converters.add(jsonMessageConverter());
+    }
+
+    /**
+     * Returns default objectMapper.
+     *
+     * @return an object mapper
+     */
+    protected ObjectMapper getObjectMapper() {
+        return defaultObjectMapper;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseObservabilityConfig.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/config/BaseObservabilityConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.config;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * {@code ObservabilityConfig} class sets the configuration setting up Tanzu Wavefront.
+ * The service utilizing this config must set the properties defined in this class configure Tanzu Wavefront.
+ *
+ * @author Francois gutt
+ */
+public class BaseObservabilityConfig {
+
+    /**
+     * Environment
+     */
+    private final Environment environment;
+
+    /**
+     * Constructor taking in environment
+     * @param environment environment being wired.
+     */
+    public BaseObservabilityConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Gets Wavefront application name
+     * @return string value of application name for wavefront.
+     */
+    public String getWavefrontApplicationName() {
+        return environment.getRequiredProperty("wavefront.application.name");
+    }
+
+    /**
+     * Gets Wavefront application service
+     * @return string value for service name of application for wavefront.
+     */
+    public String getWavefrontApplicationService() {
+        return environment.getRequiredProperty("wavefront.application.service");
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BasePaginatedServiceRequest.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BasePaginatedServiceRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code BasePaginatedServiceRequest} should be used when pagination is needed in a Poly Controller.
+ */
+public abstract class BasePaginatedServiceRequest extends BaseServiceRequest {
+
+    /**
+     * Used for services that support pagination.
+     */
+    private PageInformation pageInformation;
+
+    /**
+     * Get the pageInformation.
+     *
+     * @return the pageInformation
+     */
+    public PageInformation getPageInformation() {
+        return pageInformation;
+    }
+
+    /**
+     * Set the pageInformation.
+     *
+     * @param pageInformation the pageInformation to set
+     */
+    public void setPageInformation(PageInformation pageInformation) {
+        this.pageInformation = pageInformation;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceRequest.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.Map;
+
+/**
+ * {@code BaseServiceRequest} specifies the prototypes for all service requests.
+ *
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceRequest {
+
+    /**
+     * The service header map.
+     */
+    private Map<String, String> serviceHeaders;
+
+    /**
+     * Get the service headers map.
+     *
+     * @return a map of service headers
+     */
+    public Map<String, String> getServiceHeaders() {
+        return serviceHeaders;
+    }
+
+    /**
+     * Sets the service header map.
+     *
+     * @param serviceHeaders a map of service headers.
+     */
+    public void setServiceHeaders(Map<String, String> serviceHeaders) {
+        this.serviceHeaders = serviceHeaders;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/BaseServiceResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code BaseServiceResponse} specifies the prototypes for all service responses.
+ *
+ * @author Francois Gutt
+ */
+public abstract class BaseServiceResponse {
+
+    /**
+     * Id used to uniquely get, update or remove a resource.
+     */
+    protected String id;
+
+    /**
+     * Get the id.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the id.
+     *
+     * @param id the identifier to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+}
+

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ErrorResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ErrorResponse.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+
+/**
+ * {@code ErrorResponse} class is the response model for 4XX and 5XX series errors.
+ *
+ */
+public class ErrorResponse {
+
+    /**
+     * Error code.
+     */
+    private ErrorCode code;
+
+    /**
+     * Friendly header message that gives a brief overview of the error.
+     */
+    private String message;
+
+    /**
+     * Friendly user message to the consumer of the error.
+     */
+    private String moreInfo;
+
+    /**
+     * Message for the developer of the error and possibly a solution to fix the error.
+     */
+    private String developerMessage;
+
+    /**
+     * Argument constructor creates a new instance of ErrorResponse with given values.
+     *
+     * @param code             error code
+     * @param message          friendly header message that gives a brief overview of the error
+     * @param moreInfo         friendly user message to the consumer of the error
+     * @param developerMessage message for the developer of the error and possibly a solution to fix the error
+     */
+    public ErrorResponse(ErrorCode code, String message, String moreInfo, String developerMessage) {
+        this.code = code;
+        this.message = message;
+        this.moreInfo = moreInfo;
+        this.developerMessage = developerMessage;
+    }
+
+    /**
+     * Get the errorCode.
+     *
+     * @return the errorCode
+     */
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    /**
+     * Get the userMessage.
+     *
+     * @return the userMessage
+     */
+    public String getMoreInfo() {
+        return moreInfo;
+    }
+
+    /**
+     * Get the headerMessage.
+     *
+     * @return the headerMessage
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Get the developerMessage.
+     *
+     * @return the developerMessage
+     */
+    public String getDeveloperMessage() {
+        return developerMessage;
+    }
+
+    /**
+     * Set the developerMessage.
+     *
+     * @param developerMessage the developerMessage
+     */
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ExposedHeaders.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ExposedHeaders.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ExposedHeaders} enum has the names of the exposed HTTP headers that can be discovered in addition to the standard response HTTP headers that are exposed by Spring.
+ *
+ * @author Paolo Claudio
+ */
+public enum ExposedHeaders {
+
+    PAGE("Page"), SIZE("Size"), TOTAL_RESULTS_COUNT("Total-Results-Count");
+
+    /**
+     * Name of the exposed header.
+     */
+    private String name;
+
+    /**
+     * Argument constructor creates a new instance of ExposedHeaders with given values.
+     *
+     * @param name of the exposed header
+     */
+    ExposedHeaders(String name) {
+        setName(name);
+    }
+
+    /**
+     * Get the name.
+     *
+     * @return the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageInformation.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageInformation.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code PageInformation} class specifies the parameters for a service request,
+ * limiting the results to a subset of how many (size) and on which page (page).
+ */
+public class PageInformation {
+
+    /**
+     * The page requested of the results.
+     */
+    private int page;
+
+    /**
+     * The number of results per page.
+     */
+    private int size;
+
+    /**
+     * Get the page.
+     *
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     *
+     * @param page the page to set
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * Get the size.
+     *
+     * @return the size
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Set the size.
+     *
+     * @param size the size to set
+     */
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageResponse.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/PageResponse.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.List;
+
+
+/**
+ * {@code PageResponse} class performs the paging calculation of the results from the service response,
+ * capturing the pages and the results per page.
+ *
+ * @param <O> output type (response type)
+ */
+public class PageResponse<O extends BaseServiceResponse> {
+
+    /**
+     * The default number of results to display per page if none was provided.
+     */
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    /**
+     * Collection received as a response from the service.
+     */
+    private List<O> responses;
+
+    /**
+     * Total number of results from the service.
+     */
+    private int totalResultsCount;
+
+    /**
+     * The number of results per page.
+     */
+    private int pageSize;
+
+    /**
+     * The page index.
+     */
+    private int page;
+
+    /**
+     * The starting range of the results.
+     */
+    private int startingIndex;
+
+    /**
+     * The ending range of the results.
+     */
+    private int endingIndex;
+
+    /**
+     * The maximum number of pages.
+     */
+    private int maxPages;
+
+    /**
+     * Argument constructor creates a new instance of PageResponse with given values.
+     *
+     * @param responses collection received as a response from the service
+     */
+    public PageResponse(List<O> responses) {
+        this.responses = responses;
+    }
+
+    /**
+     * Argument constructor creates a new instance of PageResponse with given values.
+     *
+     * @param responses       collection received as a response from the service
+     * @param pageInformation containing the requested page and size from the request to the service
+     */
+    public PageResponse(List<O> responses, PageInformation pageInformation) {
+        this.responses = responses;
+        this.page = pageInformation.getPage();
+        this.pageSize = pageInformation.getSize();
+        if (pageSize < 0) {
+            pageSize = DEFAULT_PAGE_SIZE;
+        }
+        this.totalResultsCount = responses.size();
+        if (pageSize > this.totalResultsCount) {
+            pageSize = this.totalResultsCount;
+        }
+        calculatePages();
+        setPage(this.page);
+        this.responses = responses.subList(this.startingIndex, this.endingIndex);
+    }
+
+    /**
+     * Get the responses.
+     *
+     * @return the responses
+     */
+    public List<O> getResponses() {
+        return responses;
+    }
+
+    /**
+     * Set the responses.
+     *
+     * @param responses the responses to set
+     */
+    public void setResponses(List<O> responses) {
+        this.responses = responses;
+    }
+
+    /**
+     * Get the totalResultsCount.
+     *
+     * @return the totalResultsCount
+     */
+    public int getTotalResultsCount() {
+        return totalResultsCount;
+    }
+
+    /**
+     * Set the totalResultsCount.
+     *
+     * @param totalResultsCount the totalResultsCount to set
+     */
+    public void setTotalResultsCount(int totalResultsCount) {
+        this.totalResultsCount = totalResultsCount;
+    }
+
+    /**
+     * Get the pageSize.
+     *
+     * @return the pageSize
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Set the pageSize.
+     *
+     * @param pageSize the pageSize to set
+     */
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+        calculatePages();
+    }
+
+    /**
+     * Get the page.
+     *
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     *
+     * @param p the page to set
+     */
+    public void setPage(int p) {
+        if (p >= maxPages) {
+            this.page = maxPages;
+        } else if (p <= 1) {
+            this.page = 1;
+        } else {
+            this.page = p;
+        }
+
+        // Determine where the sublist starts and ends
+        startingIndex = pageSize * (page - 1);
+        if (startingIndex < 0) {
+            startingIndex = 0;
+        }
+
+        endingIndex = startingIndex + pageSize;
+        if (endingIndex > responses.size()) {
+            endingIndex = responses.size();
+        }
+    }
+
+    /**
+     * Gets the maxPages.
+     *
+     * @return the maxPages
+     */
+    public int getMaxPages() {
+        return maxPages;
+    }
+
+    /**
+     * Calculate the number of max pages from the responses.
+     */
+    private void calculatePages() {
+        if (pageSize > 0) {
+            if (responses.size() % pageSize == 0) {
+                maxPages = responses.size() / pageSize;
+            } else {
+                maxPages = (responses.size() / pageSize) + 1;
+            }
+        }
+    }
+
+    /**
+     * Get a subset of all of the responses.
+     *
+     * @return a subset of all of the responses
+     */
+    public List<O> getResponsesForPage() {
+        return responses.subList(startingIndex, endingIndex);
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderKey.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderKey.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ServiceHeaderKey} enum will hold all of the key values for the service headers.
+ *
+ */
+public enum ServiceHeaderKey {
+
+    /**
+     * Authorization.
+     */
+    AUTHORIZATION("Authorization"),
+
+    /**
+     * Client identifier.
+     */
+    CLIENT_ID("Client-ID"),
+
+    /**
+     * Client version.
+     */
+    CLIENT_VERSION("Client-Version"),
+
+    /**
+     * Correlation Identifier Key.
+     */
+    CORRELATION_IDENTIFIER_KEY("Correlation-ID"),
+
+    /**
+     * Use Case Name Key.
+     */
+    USE_CASE_NAME_KEY("Journey-ID");
+
+    /**
+     * Value/name of the enum.
+     */
+    private String value;
+
+    /**
+     * Constructor which sets the default value of the enum.
+     *
+     * @param value actual name of the enum.
+     */
+    ServiceHeaderKey(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the value/name of the enum.
+     *
+     * @return the name of the enum to be returned.
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderValue.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaderValue.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+/**
+ * {@code ClientHeaderValue} enum is used to house all the header values for the clients.
+ *
+ */
+public enum ServiceHeaderValue {
+
+    /**
+     * Correlation Identifier value.
+     */
+    CORRELATION_IDENTIFIER_VALUE("1234"),
+
+    /**
+     * Client Identifier Value.
+     */
+    CLIENT_IDENTIFIER_VALUE("AppName");
+
+    /**
+     * The value of the enum.
+     */
+    private String value;
+
+    /**
+     * The constructor that sets the default value of the enum.
+     *
+     * @param value value of the enum to set.
+     */
+    ServiceHeaderValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the value of the enum.
+     *
+     * @return the value of the enum to return.
+     */
+    public String getValue() {
+        return value;
+    }
+
+
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaders.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeaders.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceHeaders} class contains the header information received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceHeaders {
+
+    /**
+     * Trace elements.
+     */
+    private ServiceTrace trace;
+
+    /**
+     * Routing elements.
+     */
+    private ServiceRouting routing;
+
+    /**
+     * Default constructor creates a new instance of ServiceHeaders with default values.
+     */
+    public ServiceHeaders() {
+        // Fields are set via set methods
+    }
+
+    /**
+     * Get the trace.
+     *
+     * @return the trace
+     */
+    public ServiceTrace getTrace() {
+        return trace;
+    }
+
+    /**
+     * Set the trace.
+     *
+     * @param trace the trace to set
+     */
+    public void setTrace(ServiceTrace trace) {
+        this.trace = trace;
+    }
+
+    /**
+     * Get the routing.
+     *
+     * @return the routing
+     */
+    public ServiceRouting getRouting() {
+        return routing;
+    }
+
+    /**
+     * Set the routing.
+     *
+     * @param routing the routing to set
+     */
+    public void setRouting(ServiceRouting routing) {
+        this.routing = routing;
+    }
+
+    /**
+     * Check to see if another ServiceHeaders object equals this ServiceHeaders object.
+     *
+     * @param o another ServiceHeaders object
+     * @return true if and only if another ServiceHeaders object equals this ServiceHeaders object.
+     */
+    @Override
+    public boolean equals(Object o) {
+
+        if (o == this) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+
+        ServiceHeaders other = (ServiceHeaders) o;
+        return Objects.equals(routing, other.routing)
+                && Objects.equals(trace, other.trace);
+    }
+
+    /**
+     * Return the hash code of this object.
+     *
+     * @return hash code of this object
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(routing, trace);
+    }
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceHeaders{" +
+                "trace=" + trace +
+                ", routing=" + routing +
+                '}';
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeadersFactory.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceHeadersFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code ServiceHeadersFactory} class produces ServiceHeaders objects.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceHeadersFactory {
+
+    /**
+     * Default constructor.
+     */
+    private ServiceHeadersFactory() {
+    }
+
+    /**
+     * Create a ServiceHeaders object given HTTP headers.
+     *
+     * @param headers containing the HTTP headers
+     * @return the ServiceHeaders object
+     */
+    public static ServiceHeaders create(HttpHeaders headers) {
+        ServiceTrace trace = new ServiceTrace();
+        trace.setCorrelationId(headers.getFirst(ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY.getValue()));
+
+        ServiceRouting routing = new ServiceRouting();
+        ServiceHeaders serviceHeaders = new ServiceHeaders();
+        serviceHeaders.setTrace(trace);
+        serviceHeaders.setRouting(routing);
+
+        return serviceHeaders;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceRouting.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceRouting.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceRouting} class contains the routing elements received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceRouting {
+
+    /**
+     * Client Identifier.
+     */
+    private String clientId;
+
+    /**
+     * Default constructor creates a new instance of ServiceRouting with default values.
+     */
+    public ServiceRouting() {
+
+        // Fields are set via set methods
+    }
+
+
+    /**
+     * Gets the client identifier.
+     *
+     * @return the client identifier.
+     */
+    @ApiModelProperty(value = "Unique client id assigned to the consumer")
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Sets the client identifier.
+     *
+     * @param clientId the client identifier to set.
+     */
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceRouting that = (ServiceRouting) o;
+
+        return Objects.equals(clientId, that.clientId);
+    }
+
+    @Override
+    public int hashCode() {
+        return clientId != null ? clientId.hashCode() : 0;
+    }
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceRouting{" +
+                "clientId='" + clientId + '\'' +
+                '}';
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceTrace.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/model/ServiceTrace.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+/**
+ * {@code ServiceTrace} class contains the trace elements received from the consumer.
+ *
+ * @author Paolo Claudio
+ */
+public class ServiceTrace {
+
+    /**
+     * Correlation ID.
+     */
+    private String correlationId;
+
+    /**
+     * Default constructor creates a new instance of ServiceTrace with default values.
+     */
+    public ServiceTrace() {
+
+        // Fields are set via set methods
+    }
+
+    /**
+     * Get the correlationId.
+     *
+     * @return the correlationId
+     */
+    @ApiModelProperty(value = "This is a unique identifier used for operational logging purposes")
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    /**
+     * Set the correlationId.
+     *
+     * @param correlationId the correlationId to set
+     */
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+
+    /**
+     * Return the string representation of this object.
+     *
+     * @return the string representation of this object
+     */
+    @Override
+    public String toString() {
+        return "ServiceTrace{" +
+                "correlationId='" + correlationId + '\'' +
+                '}';
+    }
+
+    /**
+     * Equals.
+     * @param o an object
+     * @return a boolean
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ServiceTrace that = (ServiceTrace) o;
+
+        return Objects.equals(correlationId, that.correlationId);
+    }
+
+    /**
+     * hashCode.
+     * @return an integer hash
+     */
+    @Override
+    public int hashCode() {
+        return correlationId != null ? correlationId.hashCode() : 0;
+    }
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseCreateImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseCreateImperativeService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseCreateService} class specifies the prototypes for performing business logic.
+ * @param <I> input request type
+ * @param <O> output response type
+ * @author Francois Gutt
+ */
+public abstract class BaseCreateImperativeService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Add a single resource.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    public O create(HttpHeaders headers, I request) {
+        logger.entry(request);
+        final O response = executeCreate(headers, request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for adding a resource.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    protected abstract O executeCreate(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseDeleteImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseDeleteImperativeService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseDeleteService} class specifies the prototypes for performing business logic.
+ * @author Francois Gutt
+ */
+public abstract class BaseDeleteImperativeService extends BaseService {
+
+    /**
+     * Remove a single resource.
+     *
+     * @param headers received from the controller
+     */
+    public void delete(HttpHeaders headers) {
+        logger.entry(headers);
+        executeDelete(headers);
+        logger.exit();
+    }
+
+    /**
+     * Prototype for removing a resource.
+     * @param headers received from the controller
+     */
+    protected abstract void executeDelete(HttpHeaders headers);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetMonoImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetMonoImperativeService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseGetMonoService} class specifies the prototypes for performing business logic.
+ * @param <O> BaseServiceResponse
+ * @author Francois Gutt
+ */
+public abstract class BaseGetMonoImperativeService<O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Unique identifier for the resource.
+     *
+     * @param headers the http headers
+     * @return a service response
+     */
+    public O read(HttpHeaders headers) {
+        logger.entry(headers);
+        O response = executeRead(headers);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     *
+     * @param headers the http headers
+     * @return a service response
+     */
+    protected abstract O executeRead(HttpHeaders headers);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetPolyImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseGetPolyImperativeService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+public class BaseGetPolyImperativeService {
+
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadMonoImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadMonoImperativeService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseReadMonoService} class specifies the prototypes for performing business logic.
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @param <O> class extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadMonoImperativeService<I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Get a single resource from the back end service.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return a single resource from the back end service.
+     */
+    public O read(HttpHeaders headers, I request) {
+        logger.entry(request);
+        final O response = executeRead(headers, request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     * @param headers the http header map
+     * @param request the request
+     * @return a read mono response
+     */
+    protected abstract O executeRead(HttpHeaders headers,I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadPolyImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseReadPolyImperativeService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.imperative.model.BaseServiceResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseReadPolyService} class specifies the prototypes for performing business logic.
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @param <O> class extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadPolyImperativeService <I extends BaseServiceRequest, O extends BaseServiceResponse> extends BaseService {
+
+    /**
+     * Get multiple resources from the back end service.
+     * @param headers received from the controller
+     * @param request body received from the controller
+     * @return a single resource from the back end service.
+     */
+    public Page<O> read(HttpHeaders headers, final I request) {
+        logger.entry(request);
+        final Page<O> responses = executeRead(headers, request);
+        logger.exit(responses);
+        return responses;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     * @param headers the Http header map
+     * @param request a read poly request
+     * @return a page of responses
+     */
+    protected abstract Page<O> executeRead(HttpHeaders headers,I request);
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+
+/**
+ * {@code BaseService} The base service every child controller should extend this parent service.
+ * @author Francois Gutt
+ */
+public abstract class BaseService {
+
+    /**
+     * Logger for the base service.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(getClass());
+}

--- a/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseUpdateImperativeService.java
+++ b/service/synapse-service-imperative/src/main/java/io/americanexpress/synapse/service/imperative/service/BaseUpdateImperativeService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.imperative.service;
+
+import io.americanexpress.synapse.service.imperative.model.BaseServiceRequest;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * {@code BaseUpdateService} class specifies the prototypes for performing business logic.
+ *
+ * @param <I> class extending the {@link BaseServiceRequest}
+ * @author Francois Gutt
+ */
+public abstract class BaseUpdateImperativeService<I extends BaseServiceRequest> extends BaseService {
+
+    /**
+     * Update a single resource.
+     *
+     * @param request body received from the controller
+     */
+    public void update(HttpHeaders headers, I request) {
+        logger.entry(request);
+        executeUpdate(headers, request);
+        logger.exit();
+    }
+
+    /**
+     * Prototype for updating a resource.
+     *
+     * @param request body received from the controller
+     */
+    protected abstract void executeUpdate(HttpHeaders headers, I request);
+}

--- a/service/synapse-service-imperative/src/main/resources/banner.txt
+++ b/service/synapse-service-imperative/src/main/resources/banner.txt
@@ -1,0 +1,36 @@
+# Copyright 2020 American Express Travel Related Services Company, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+${Ansi.BLUE}           *##&
+${Ansi.BLUE}        ,########(
+${Ansi.BLUE}        ##########
+${Ansi.BLUE}         ########                 %#(
+${Ansi.BLUE}               #                ######*
+${Ansi.BLUE}                %#              #####(
+${Ansi.BLUE}  ####            #.         @#
+${Ansi.BLUE}%#######           *######/#%
+${Ansi.BLUE} ######* @#####&   ##########
+${Ansi.BLUE}                  ############
+${Ansi.BLUE}                  ###########&
+${Ansi.BLUE}                    %######/     /###/     ######
+${Ansi.BLUE}                        #                *########
+${Ansi.BLUE}                        %(                ########
+${Ansi.BLUE}                         #                  @##@
+${Ansi.BLUE}                         #(
+${Ansi.BLUE}                       /#####
+${Ansi.BLUE}                       #######
+${Ansi.BLUE}                ______     __  __     __   __     ______     ______   ______     ______
+${Ansi.BLUE}               /\  ___\   /\ \_\ \   /\ "-.\ \   /\  __ \   /\  == \ /\  ___\   /\  ___\
+${Ansi.BLUE}               \ \___  \  \ \____ \  \ \ \-.  \  \ \  __ \  \ \  _-/ \ \___  \  \ \  __\
+${Ansi.BLUE}                \/\_____\  \/\_____\  \ \_\\"\_\  \ \_\ \_\  \ \_\    \/\_____\  \ \_____\
+${Ansi.BLUE}                 \/_____/   \/_____/   \/_/ \/_/   \/_/\/_/   \/_/     \/_____/   \/_____/
+${Ansi.BLUE} :: Synapse :: :: Application${application.title} :: ${application.formatted-version} :: Spring Boot${spring-boot.formatted-version} :: ${Ansi.DEFAULT}
+``

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service</artifactId>
+        <version>0.3.31-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>synapse-service-reactive</artifactId>
+
+    <!--Dependencies-->
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <!--Synapse-->
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-api-docs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-utilities-common</artifactId>
+        </dependency>
+
+        <!--Spring-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/config/BaseReactiveServiceRestConfig.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/config/BaseReactiveServiceRestConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.americanexpress.synapse.framework.api.docs.ApiDocsConfig;
+import io.americanexpress.synapse.framework.exception.config.ExceptionConfig;
+import io.americanexpress.synapse.utilities.common.config.UtilitiesCommonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+/**
+ * {@code BaseServiceReactiveRestConfig} sets common configurations for the service layer.
+ *
+ * @author Francois Gutt
+ */
+@Configuration
+@EnableWebFlux
+@ComponentScan(basePackages = "io.americanexpress.synapse.service.reactive")
+@Import({ExceptionConfig.class, ApiDocsConfig.class, UtilitiesCommonConfig.class})
+public class BaseReactiveServiceRestConfig implements WebFluxConfigurer {
+
+    /**
+     * Default object mapper.
+     */
+    private final ObjectMapper defaultObjectMapper;
+
+    /**
+     * Constructor taking in objectMapper.
+     *
+     * @param defaultObjectMapper   the default object mapper.
+     */
+    @Autowired
+    public BaseReactiveServiceRestConfig(ObjectMapper defaultObjectMapper) {
+        this.defaultObjectMapper = defaultObjectMapper;
+    }
+
+    /**
+     * Configures the HTTP message readers and writers for reading from the request body and
+     * for writing to the response body in annotated controllers and functional endpoints.
+     *
+     * @param configurer the service codec configurer
+     */
+    @Override
+    public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+        configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(getObjectMapper()));
+        configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(getObjectMapper()));
+    }
+
+    /**
+     * Returns default objectMapper.
+     *
+     * @return an object mapper
+     */
+    protected ObjectMapper getObjectMapper() {
+        return defaultObjectMapper;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BasePaginatedServiceRequest.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BasePaginatedServiceRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code BasePaginatedServiceRequest} should be used when pagination is needed in a Poly Controller.
+ *
+ * @author Francois Gutt
+ */
+public abstract class BasePaginatedServiceRequest implements BaseServiceRequest {
+
+    /**
+     * Used for services that support pagination.
+     */
+    private PageInformation pageInformation;
+
+    /**
+     * Get the pageInformation.
+     *
+     * @return the pageInformation
+     */
+    public PageInformation getPageInformation() {
+        return pageInformation;
+    }
+
+    /**
+     * Set the pageInformation.
+     *
+     * @param pageInformation the pageInformation to set
+     */
+    public void setPageInformation(PageInformation pageInformation) {
+        this.pageInformation = pageInformation;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceRequest.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code BaseServiceRequest} specifies the prototypes for all service requests.
+ *
+ * @author Francois Gutt
+ */
+public interface BaseServiceRequest {
+
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceResponse.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/BaseServiceResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code BaseServiceResponse} specifies the prototypes for all service responses.
+ *
+ * @author Francois Gutt
+ */
+public interface BaseServiceResponse {
+
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ErrorResponse.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ErrorResponse.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+import io.americanexpress.synapse.framework.exception.model.ErrorCode;
+
+/**
+ * {@code ErrorResponse} class is the response model for 4XX and 5XX series errors.
+ *
+ * @author Francois Gutt
+ */
+public class ErrorResponse {
+
+    /**
+     * Error code.
+     */
+    private ErrorCode code;
+
+    /**
+     * Friendly header message that gives a brief overview of the error.
+     */
+    private String message;
+
+    /**
+     * Friendly user message to the consumer of the error.
+     */
+    private String moreInfo;
+
+    /**
+     * Message for the developer of the error and possibly a solution to fix the error.
+     */
+    private String developerMessage;
+
+    /**
+     * Creates a new instance of ErrorResponse with given values.
+     *
+     * @param code             error code
+     * @param message          friendly header message that gives a brief overview of the error
+     * @param moreInfo         friendly user message to the consumer of the error
+     * @param developerMessage message for the developer of the error and possibly a solution to fix the error
+     */
+    public ErrorResponse(ErrorCode code, String message, String moreInfo, String developerMessage) {
+        this.code = code;
+        this.message = message;
+        this.moreInfo = moreInfo;
+        this.developerMessage = developerMessage;
+    }
+
+    /**
+     * Get the errorCode.
+     *
+     * @return the errorCode
+     */
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    /**
+     * Get the userMessage.
+     *
+     * @return the userMessage
+     */
+    public String getMoreInfo() {
+        return moreInfo;
+    }
+
+    /**
+     * Get the headerMessage.
+     *
+     * @return the headerMessage
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Get the developerMessage.
+     *
+     * @return the developerMessage
+     */
+    public String getDeveloperMessage() {
+        return developerMessage;
+    }
+
+    /**
+     * Set the developerMessage.
+     *
+     * @param developerMessage the developerMessage
+     */
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ExposedHeaders.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/ExposedHeaders.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code ExposedHeaders} enum has the names of the exposed HTTP headers that can be discovered in addition to the standard response HTTP headers that are exposed by Spring.
+ *
+ * @author Paolo Claudio
+ */
+public enum ExposedHeaders {
+
+    PAGE("Page"), SIZE("Size"), TOTAL_RESULTS_COUNT("Total-Results-Count");
+
+    /**
+     * Name of the exposed header.
+     */
+    private String name;
+
+    /**
+     * Argument constructor creates a new instance of ExposedHeaders with given values.
+     *
+     * @param name of the exposed header
+     */
+    ExposedHeaders(String name) {
+        setName(name);
+    }
+
+    /**
+     * Get the name.
+     *
+     * @return the name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/PageInformation.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/model/PageInformation.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.model;
+
+/**
+ * {@code PageInformation} class specifies the parameters for a service request,
+ * limiting the results to a subset of how many (size) and on which page (page).
+ *
+ * @author Francois Gutt
+ */
+public class PageInformation {
+
+    /**
+     * The page requested of the results.
+     */
+    private int page;
+
+    /**
+     * The number of results per page.
+     */
+    private int size;
+
+    /**
+     * Get the page.
+     *
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * Set the page.
+     *
+     * @param page the page to set
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * Get the size.
+     *
+     * @return the size
+     */
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * Set the size.
+     *
+     * @param size the size to set
+     */
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseCreateReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseCreateReactiveService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseCreateReactiveService} specifies the prototypes for performing business logic.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseCreateReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Add a single resource.
+     *
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    public Mono<O> create(I request) {
+        logger.entry(request);
+        final var response = executeCreate(request);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for adding a resource.
+     *
+     * @param request body received from the controller
+     * @return response body to the controller
+     */
+    protected abstract Mono<O> executeCreate(I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseDeleteReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseDeleteReactiveService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseDeleteReactiveService} class specifies the prototypes for performing business logic.
+ *
+ * @author Francois Gutt
+ */
+public abstract class BaseDeleteReactiveService<
+            I extends BaseServiceRequest
+        > extends BaseService {
+    /**
+     * Deletes a resource by id.
+     *
+     * @return a mono void
+     */
+    public Mono<Void> delete(I serviceRequest) {
+        logger.entry();
+        var results = executeDelete(serviceRequest);
+        logger.exit();
+        return results;
+    }
+
+    /**
+     * Prototype for deleting a resource.
+     *
+     * @return a mono void
+     */
+    protected abstract Mono<Void> executeDelete(I serviceRequest);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetFluxReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetFluxReactiveService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@code BaseGetFluxReactiveService} class specifies the prototypes for performing business logic.
+ *
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseGetFluxReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Retrieves multiple resource.
+     *
+     * @return a flux read response
+     */
+    public Flux<O> read(I serviceRequest) {
+        logger.entry();
+        var response = executeRead(serviceRequest);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     *
+     * @return a flux read response
+     */
+    protected abstract Flux<O> executeRead(I serviceRequest);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetMonoReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseGetMonoReactiveService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseGetMonoReactiveService} class specifies the prototypes for performing business logic.
+ *
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseGetMonoReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Retrieves one resource.
+     *
+     * @param serviceRequest the service request
+     * @return a mono read response
+     */
+    public Mono<O> read(I serviceRequest) {
+        logger.entry(serviceRequest);
+        final var response = executeRead(serviceRequest);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     *
+     * @param serviceRequest the service request
+     * @return a mono read response
+     */
+    protected abstract Mono<O> executeRead(I serviceRequest);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadFluxReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadFluxReactiveService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import org.springframework.http.HttpHeaders;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@code BaseReadFluxReactiveService} class specifies the prototypes for performing business logic.
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadFluxReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Retrieves multiple resources with a request body.
+     *
+     * @param request a base service request
+     * @return a flux read response
+     */
+    public Flux<O> read(final I request) {
+        logger.entry(request);
+        final var response  = executeRead(request);
+        logger.exit(response);
+        return response;
+    }
+
+    /**
+     * Prototype for reading multiple resources.
+     *
+     * @param request a base service request
+     * @return a flux read response
+     */
+    protected abstract Flux<O> executeRead(I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadMonoReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseReadMonoReactiveService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseReadMonoReactiveService} class specifies the prototypes for performing business logic.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseReadMonoReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Retrieves one resource with a request body.
+     *
+     * @param request a service request
+     * @return a mono service response
+     */
+    public Mono<O> read(I request) {
+        logger.entry(request);
+        final var response = executeRead(request);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     *
+     * @param request a service request
+     * @return a mono service response
+     */
+    protected abstract Mono<O> executeRead(I request);
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+
+/**
+ * {@code BaseService} specifies the prototypes for all services.
+ *
+ * @author Francois Gutt
+ */
+public abstract class BaseService {
+
+    /**
+     * Logger for the base service.
+     */
+    protected final XLogger logger = XLoggerFactory.getXLogger(getClass());
+
+}

--- a/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseUpdateReactiveService.java
+++ b/service/synapse-service-reactive/src/main/java/io/americanexpress/synapse/service/reactive/service/BaseUpdateReactiveService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.americanexpress.synapse.service.reactive.service;
+
+import io.americanexpress.synapse.service.reactive.model.BaseServiceRequest;
+import io.americanexpress.synapse.service.reactive.model.BaseServiceResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code BaseUpdateReactiveService} class specifies the prototypes for performing business logic.
+ *
+ * @param <I> an object extending the {@link BaseServiceRequest}
+ * @param <O> an object extending the {@link BaseServiceResponse}
+ * @author Francois Gutt
+ */
+public abstract class BaseUpdateReactiveService<
+            I extends BaseServiceRequest,
+            O extends BaseServiceResponse
+        > extends BaseService {
+
+    /**
+     * Update a single resource reactively.
+     *
+     * @param request body received from the controller
+     * @return a mono void
+     */
+    public Mono<Void> update(I request) {
+        logger.entry(request);
+        var results = executeUpdate(request);
+        logger.exit();
+        return results;
+    }
+
+    /**
+     * Prototype for updating a resource.
+     *
+     * @param request body received from the controller
+     * @return a mono void
+     */
+    protected abstract Mono<Void> executeUpdate(I request);
+}


### PR DESCRIPTION
## API Base module

### Description

In order to separate the protocol layer with the logic layer, the service has been split into 2 different modules.
api layer with api service rest both imperative and reactive.
and the service has been split with service imperative and reactive, notice that the service has now no knowledge of the http layer and can therefore be inter change seamlessly between different protocols.

### What was changed in this PR

- adding the api layer
- adding the service layer agnostic of the protocol