### PR TITLE
feature(synapse-data-mongodb): add id back

### DIFF
--- a/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/entity/BaseEntity.java
+++ b/data/synapse-data-mongodb/src/main/java/io/americanexpress/synapse/data/mongodb/entity/BaseEntity.java
@@ -16,12 +16,9 @@ package io.americanexpress.synapse.data.mongodb.entity;
 
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Version;
-
-
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -30,6 +27,12 @@ import java.util.Objects;
  * All the common attributes are consolidated in this entity.
  */
 public abstract class BaseEntity {
+
+    /**
+     * Id.
+     * It can be overridden by the child class with the @Id annotation on a field.
+     */
+    private String id;
 
     /**
      * Created Date Time
@@ -65,6 +68,14 @@ public abstract class BaseEntity {
      * Empty constructor, do not delete it. It is used by Spring Data.
      */
     public BaseEntity() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public LocalDateTime getCreatedDateTime() {
@@ -111,13 +122,13 @@ public abstract class BaseEntity {
     public boolean equals(Object object) {
         if (this == object) return true;
         if (!(object instanceof BaseEntity that)) return false;
-        return Objects.equals(createdDateTime, that.createdDateTime) &&
+        return Objects.equals(id, that.id) && Objects.equals(createdDateTime, that.createdDateTime) &&
                 Objects.equals(lastModifiedDateTime, that.lastModifiedDateTime) && Objects.equals(createdBy, that.createdBy) &&
                 Objects.equals(lastModifiedBy, that.lastModifiedBy) && Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(createdDateTime, lastModifiedDateTime, createdBy, lastModifiedBy, version);
+        return Objects.hash(id, createdDateTime, lastModifiedDateTime, createdBy, lastModifiedBy, version);
     }
 }

--- a/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/validator/OneOfValidator.java
+++ b/utility/synapse-utilities-common/src/main/java/io/americanexpress/synapse/utilities/common/validator/OneOfValidator.java
@@ -15,6 +15,7 @@ package io.americanexpress.synapse.utilities.common.validator;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.lang.reflect.InvocationTargetException;
@@ -60,7 +61,7 @@ public class OneOfValidator implements ConstraintValidator<OneOf, Object> {
             var isOneOf = false;
             for (String fieldName : fieldNames) {
                 var property = PropertyUtils.getProperty(object, fieldName);
-                if (!isEmpty(property)) {
+                if (!isEmpty(property) && (!property.getClass().equals(String.class) || StringUtils.isNotBlank((String) property))) {
                     if (isOneOf) {
                         isOneOf = false;
                         break;

--- a/utility/synapse-utilities-common/src/test/java/io/americanexpress/synapse/utilities/common/validator/OneOfValidatorTest.java
+++ b/utility/synapse-utilities-common/src/test/java/io/americanexpress/synapse/utilities/common/validator/OneOfValidatorTest.java
@@ -71,7 +71,7 @@ class OneOfValidatorTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"test,", ",test", "test,   ", "   ,test"})
+    @CsvSource({"test,", ",test", "test,'   '", "'   ',test"})
     void isValid_givenObjectWithOneNotBlankField_expectedTrue(String value1, String value2) {
         var sampleNestedObject  = new SampleNestedObject();
         sampleNestedObject.setSomeText1(value1);
@@ -80,7 +80,7 @@ class OneOfValidatorTest {
     }
 
     @ParameterizedTest
-    @CsvSource({",", "   ,   ", "test,test", "'',''", ",''"})
+    @CsvSource({",", "'   ','   '", "test,test", "'',''", ",''"})
     void isInvalid_givenObjectWithInvalidFields_expectedFalse(String value1, String value2) {
         var builder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
         when(constraintValidatorContext.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);


### PR DESCRIPTION
Adding the `id` field back to the MongoDB `BaseEntity` class.

Also changing the `OneOfValidator` to check for blank strings.