### PR TITLE
Feature/base model pojotest 

### DIFF
--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -30,7 +30,10 @@
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>synapse-framework-logging</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.americanexpress.synapse</groupId>
+            <artifactId>synapse-framework-exception</artifactId>
+        </dependency>
         <!--Third-Party-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
+++ b/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
@@ -64,12 +64,6 @@ public class BaseModelsTest {
     ));
 
     /**
-     * Default constructor. Excludes the current class and the ExcludeClassAndTestClass from validation.
-     */
-    public BaseModelsTest() {
-
-    }
-    /**
      * Validates all models in the specified package, except those explicitly excluded, using OpenPojo and EqualsVerifier.
      * It first tests enums for custom method integrity, then tests other POJOs for standard conventions and correct equals and hashCode methods.
      */

--- a/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
+++ b/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
@@ -101,23 +101,12 @@ public class BaseModelsTest {
     private void validatePojoClass(PojoClass pojoClass) {
         var pojoClazz = pojoClass.getClazz();
         if (!Modifier.isAbstract(pojoClazz.getModifiers())) {
-            try {
-                Assertions.assertPojoMethodsFor(pojoClazz).areWellImplemented();
-                EqualsVerifier.simple().forClass(pojoClazz)
-                        .suppress(warningsToSuppress.get(0))
-                        .suppress(warningsToSuppress.get(3))
-                        .verify();
-                Arrays.stream(pojoClazz.getConstructors()).map(constructor ->
-                    assertDoesNotThrow(() -> constructor.newInstance(new Object[constructor.getParameterCount()])
-                ));
-                assertDoesNotThrow(() -> pojoClazz.getConstructors());
-            } catch (AbstractAssertionError assertionError) {
-                if (assertionError.getMessage().contains("hashCode")) {
-                    assertTrue(pojoClazz.hashCode() != 0);
-                } else {
-                    throw assertionError;
-                }
-            }
+            Assertions.assertPojoMethodsFor(pojoClazz).areWellImplemented();
+            EqualsVerifier.simple().forClass(pojoClazz)
+                    .suppress(warningsToSuppress.get(0))
+                    .suppress(warningsToSuppress.get(3))
+                    .verify();
+
         }
     }
     /**

--- a/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
+++ b/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
@@ -55,8 +55,6 @@ public class BaseModelsTest {
      */
     private final List<Warning> warningsToSuppress = new ArrayList<>(List.of(
             Warning.ALL_FIELDS_SHOULD_BE_USED,
-            Warning.INHERITED_DIRECTLY_FROM_OBJECT,
-            Warning.NONFINAL_FIELDS,
             Warning.STRICT_INHERITANCE
     ));
     /**
@@ -102,11 +100,9 @@ public class BaseModelsTest {
         var pojoClazz = pojoClass.getClazz();
         if (!Modifier.isAbstract(pojoClazz.getModifiers())) {
             Assertions.assertPojoMethodsFor(pojoClazz).areWellImplemented();
-            EqualsVerifier.simple().forClass(pojoClazz)
-                    .suppress(warningsToSuppress.get(0))
-                    .suppress(warningsToSuppress.get(3))
+            EqualsVerifier.forClass(pojoClazz)
+                    .suppress(warningsToSuppress.toArray(new Warning[0]))
                     .verify();
-
         }
     }
     /**

--- a/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
+++ b/framework/synapse-framework-test/src/main/java/io/americanexpress/synapse/framework/test/model/BaseModelsTest.java
@@ -16,6 +16,7 @@ package io.americanexpress.synapse.framework.test.model;
 import com.openpojo.reflection.PojoClass;
 import com.openpojo.reflection.PojoClassFilter;
 import com.openpojo.reflection.impl.PojoClassFactory;
+import io.americanexpress.synapse.framework.exception.ApplicationServerException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
@@ -38,10 +39,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Luis Diaz, Angel Varela
  */
 public class BaseModelsTest {
+
     /**
      * The set of excluded suffixes.
      */
     private static final Set<String> EXCLUDED_SUFFIXES = new HashSet<>(Arrays.asList("Builder", "Test", "IT"));
+
     /**
      * The set of excluded class names.
      */
@@ -49,10 +52,12 @@ public class BaseModelsTest {
             BaseModelsTest.class.getName(),
             ExcludeClassAndTestClass.class.getName()
     ));
+
     /**
      * The package name.
      */
     private String packageName = this.getClass().getPackageName();
+
     /**
      * The list of suppressed warnings.
      */
@@ -76,6 +81,7 @@ public class BaseModelsTest {
         //testing non enum classes
         partitionedClasses.get(false).forEach(this::validatePojoClass);
     }
+
     /**
      * Adds additional warnings to suppress in EqualsVerifier tests.
      * This method allows customization of the EqualsVerifier behavior by adding more warnings to ignore during tests.
@@ -85,6 +91,7 @@ public class BaseModelsTest {
     protected void addWarningsToSuppress(Warning... additionalWarnings) {
         Collections.addAll(warningsToSuppress, additionalWarnings);
     }
+
     /**
      * Excludes specific classes by their names from being validated.
      * This method allows specifying class names that should not be included in the validation process.
@@ -94,6 +101,7 @@ public class BaseModelsTest {
     protected void excludeClasses(Class<?>... classes) {
         Arrays.stream(classes).forEach(clazz -> excludedClassNames.add(clazz.getName()));
     }
+
     /**
      * Validates a single POJO class for compliance with POJO conventions and correct implementation of equals and hashCode methods.
      * It uses the OpenPojo and EqualsVerifier libraries for validation.
@@ -115,6 +123,7 @@ public class BaseModelsTest {
             assertTrue(pojoClazz.hashCode() != 0 );
         }
     }
+
     /**
      * Tests an enum class for custom method integrity by invoking all its declared methods (excluding synthetic and standard enum methods).
      * Ensures that no method invocation returns null and handles any reflective operation exceptions.
@@ -131,6 +140,7 @@ public class BaseModelsTest {
                         && (method.getName().startsWith("get") || method.getName().startsWith("set")))
                 .forEach(method -> testEnumMethod(enumConstants, method));
     }
+
     /**
      * Tests a specific method of an enum class by invoking it on all enum constants and verifying the method's result.
      * Asserts that the method invocation does not return null and handles any exceptions during the reflective call.
@@ -143,8 +153,8 @@ public class BaseModelsTest {
             try {
                 var result = method.invoke(enumConstant);
                 assertNotNull(result, "Method " + method.getName() + " returned null for " + enumConstant);
-            } catch (Exception e) {
-                throw new RuntimeException("Error testing enum method " + method.getName() + " for enum constant " + enumConstant, e);
+            } catch (Exception exception) {
+                throw new ApplicationServerException(exception);
             }
         });
     }

--- a/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookConstants.java
+++ b/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookConstants.java
@@ -1,0 +1,25 @@
+package io.americanexpress.service.book.rest.model;
+
+/**
+ * {@code BookConstants} class defines the constants for the book module.
+ *
+ * @author LuisDiaz79
+ */
+public class BookConstants {
+    /**
+     * The title of the book.
+     */
+    public static String TITLE = "title";
+    /**
+     * The author of the book.
+     */
+    public static String AUTHOR = "author";
+    /**
+     * The createdDateTime of the book record.
+     */
+    public static String CREATED_BY = "createdBy";
+    /**
+     * The lastModifiedDateTime of the book record.
+     */
+    public static String BOOK_TYPE = "bookType";
+}

--- a/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookRequest.java
+++ b/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookRequest.java
@@ -16,6 +16,8 @@ package io.americanexpress.service.book.rest.model;
 import io.americanexpress.synapse.service.rest.model.BaseServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.Objects;
+
 /**
  * {@code BookRequest} Parent request object.
  */
@@ -111,6 +113,30 @@ public class BookRequest implements BaseServiceRequest {
      */
     public void setAuthor(String author) {
         this.author = author;
+    }
+
+    /**
+     * Compares two objects.
+     *
+     * @param o
+     * @return
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BookRequest that = (BookRequest) o;
+        return Objects.equals(getTitle(), that.getTitle()) && Objects.equals(getAuthor(), that.getAuthor()) && Objects.equals(getCreatedBy(), that.getCreatedBy());
+    }
+
+    /**
+     * Returns the hashcode of the object.
+     *
+     * @return
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTitle(), getAuthor(), getCreatedBy());
     }
 
     /**

--- a/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookRequest.java
+++ b/service/service-samples/sample-service-rest-mysql-book/src/main/java/io/americanexpress/service/book/rest/model/BookRequest.java
@@ -16,8 +16,6 @@ package io.americanexpress.service.book.rest.model;
 import io.americanexpress.synapse.service.rest.model.BaseServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 
-import java.util.Objects;
-
 /**
  * {@code BookRequest} Parent request object.
  */
@@ -113,30 +111,6 @@ public class BookRequest implements BaseServiceRequest {
      */
     public void setAuthor(String author) {
         this.author = author;
-    }
-
-    /**
-     * Compares two objects.
-     *
-     * @param o
-     * @return
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BookRequest that = (BookRequest) o;
-        return Objects.equals(getTitle(), that.getTitle()) && Objects.equals(getAuthor(), that.getAuthor()) && Objects.equals(getCreatedBy(), that.getCreatedBy());
-    }
-
-    /**
-     * Returns the hashcode of the object.
-     *
-     * @return
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(getTitle(), getAuthor(), getCreatedBy());
     }
 
     /**

--- a/service/service-samples/sample-service-rest-mysql-book/src/test/java/io/americanexpress/service/book/rest/model/SampleModelTest.java
+++ b/service/service-samples/sample-service-rest-mysql-book/src/test/java/io/americanexpress/service/book/rest/model/SampleModelTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
- package io.americanexpress.service.book.rest.model;
+package io.americanexpress.service.book.rest.model;
 
 import io.americanexpress.synapse.framework.test.model.BaseModelsTest;
 


### PR DESCRIPTION
Adding validation for class hashcode

This PR contains code to update the BaseModelTest in synapse-framework-test module. Adding example how to use in sample-service-rest-mysql-book

This is a collaborative effort with [@VarelaTechDev](https://github.com/VarelaTechDev)