### PR TITLE
Feature/api/should not filter

### DIFF
--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
@@ -23,7 +23,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import static io.americanexpress.synapse.service.imperative.model.ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY;
 import static io.americanexpress.synapse.service.imperative.model.ServiceHeaderKey.USE_CASE_NAME_KEY;
@@ -42,7 +41,14 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     /**
      * Required HTTP header names.
      */
-    protected Collection<String> requiredHttpHeaderNames = new ArrayList<>(Arrays.asList(HttpHeaders.CONTENT_TYPE, CORRELATION_IDENTIFIER_KEY.getValue(), USE_CASE_NAME_KEY.getValue()));
+    protected List<String> requiredHttpHeaderNames = new ArrayList<>(Arrays.asList(HttpHeaders.CONTENT_TYPE, CORRELATION_IDENTIFIER_KEY.getValue(), USE_CASE_NAME_KEY.getValue()));
+
+    /**
+     * Should not filter URIs.
+     * Specifies list of paths that should not be filtered.
+     * This might include health and actuator endpoints.
+     */
+    protected List<String> urisExcludedFromFilter = new ArrayList<>();
 
     /**
      * Validate the required HTTP headers.
@@ -81,7 +87,7 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     protected List<String> getRequiredHttpHeaderNames() {
         // Note: it is possible that a service needs no request HTTP header validation
         // Should a service require request HTTP header validation, then override this method
-        return new ArrayList<>();
+        return requiredHttpHeaderNames;
     }
 
     /**
@@ -93,6 +99,6 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
      * @return true if url should not be filtered
      */
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return false;
+        return urisExcludedFromFilter.contains(request.getRequestURI());
     }
 }

--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/interceptor/BaseHttpInterceptor.java
@@ -57,12 +57,14 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         logger.entry(request, response, handler);
 
-        // If any of the required HTTP headers are missing, this request is invalid
-        String httpHeaderValue;
-        for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
-            httpHeaderValue = request.getHeader(requiredHttpHeaderName);
-            if (httpHeaderValue == null) {
-                throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.", ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+        if(!shouldNotFilter(request)){
+            // If any of the required HTTP headers are missing, this request is invalid
+            String httpHeaderValue;
+            for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
+                httpHeaderValue = request.getHeader(requiredHttpHeaderName);
+                if (httpHeaderValue == null) {
+                    throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.", ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+                }
             }
         }
 
@@ -80,5 +82,17 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
         // Note: it is possible that a service needs no request HTTP header validation
         // Should a service require request HTTP header validation, then override this method
         return new ArrayList<>();
+    }
+
+    /**
+     * Subclasses can override this method to control what requests should not be filtered.
+     * for example override the method with the following to prevent
+     * health endpoint : return request.getRequestURI().equals("/health")
+     *
+     * @param request the incoming request
+     * @return true if url should not be filtered
+     */
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return false;
     }
 }

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/interceptor/BaseHttpInterceptor.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/interceptor/BaseHttpInterceptor.java
@@ -61,13 +61,15 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         logger.entry(request, response, handler);
-
-        // If any of the required HTTP headers are missing, this request is invalid
-        String httpHeaderValue;
-        for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
-            httpHeaderValue = request.getHeader(requiredHttpHeaderName);
-            if (httpHeaderValue == null) {
-                throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.", ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+        
+        if(!shouldNotFilter(request)){
+            // If any of the required HTTP headers are missing, this request is invalid
+            String httpHeaderValue;
+            for (String requiredHttpHeaderName : getRequiredHttpHeaderNames()) {
+                httpHeaderValue = request.getHeader(requiredHttpHeaderName);
+                if (httpHeaderValue == null) {
+                    throw new ApplicationClientException("Request HTTP Header " + requiredHttpHeaderName + " is missing.", ErrorCode.MISSING_HTTP_HEADER_ERROR, requiredHttpHeaderName);
+                }
             }
         }
 
@@ -85,5 +87,17 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
         // Note: it is possible that a service needs no request HTTP header validation
         // Should a service require request HTTP header validation, then override this method
         return new ArrayList<>();
+    }
+    
+    /**
+     * Subclasses can override this method to control what requests should not be filtered.
+     * for example override the method with the following to prevent
+     * health endpoint : return request.getRequestURI().equals("/health")
+     *
+     * @param request the incoming request
+     * @return true if url should not be filtered
+     */
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return false;
     }
 }

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/interceptor/BaseHttpInterceptor.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/interceptor/BaseHttpInterceptor.java
@@ -24,7 +24,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import static io.americanexpress.synapse.service.rest.model.ServiceHeaderKey.CORRELATION_IDENTIFIER_KEY;
@@ -32,7 +31,7 @@ import static io.americanexpress.synapse.service.rest.model.ServiceHeaderKey.USE
 
 /**
  * {@code BaseHttpInterceptor} class specifies the prototypes for performing HTTP header validations for a service.
- *
+ * 
  * @author Paolo Claudio
  */
 public abstract class BaseHttpInterceptor implements HandlerInterceptor {
@@ -42,12 +41,18 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
      */
     private final XLogger logger = XLoggerFactory.getXLogger(getClass());
 
-
+    
     /**
      * Required HTTP header names.
      */
-    protected Collection<String> requiredHttpHeaderNames = new ArrayList<>(Arrays.asList(HttpHeaders.CONTENT_TYPE, CORRELATION_IDENTIFIER_KEY.getValue(), USE_CASE_NAME_KEY.getValue()));
+    protected List<String> requiredHttpHeaderNames = new ArrayList<>(Arrays.asList(HttpHeaders.CONTENT_TYPE, CORRELATION_IDENTIFIER_KEY.getValue(), USE_CASE_NAME_KEY.getValue()));
 
+    /**
+     * Should not filter URIs.
+     * Specifies list of paths that should not be filtered.
+     * This might include health and actuator endpoints.
+     */
+    protected List<String> urisExcludedFromFilter = new ArrayList<>();
 
     /**
      * Validate the required HTTP headers.
@@ -61,7 +66,7 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         logger.entry(request, response, handler);
-        
+
         if(!shouldNotFilter(request)){
             // If any of the required HTTP headers are missing, this request is invalid
             String httpHeaderValue;
@@ -86,9 +91,9 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
     protected List<String> getRequiredHttpHeaderNames() {
         // Note: it is possible that a service needs no request HTTP header validation
         // Should a service require request HTTP header validation, then override this method
-        return new ArrayList<>();
+        return requiredHttpHeaderNames;
     }
-    
+
     /**
      * Subclasses can override this method to control what requests should not be filtered.
      * for example override the method with the following to prevent
@@ -98,6 +103,6 @@ public abstract class BaseHttpInterceptor implements HandlerInterceptor {
      * @return true if url should not be filtered
      */
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return false;
+        return urisExcludedFromFilter.contains(request.getRequestURI());
     }
 }


### PR DESCRIPTION
# Adding should not filter to base interceptor.

## Description
The PR above adds should not filter methods to the base interceptor. 
It is provided in a way subclasses can override this method to control what requests should not be filtered.

## changes in this Pull request

 Added should not filter to 

1. synapse-api-rest-imperative BaseHttpInterceptor
2. synapse-client-rest BaseHttpInterceptor