### PR TITLE
feat: add spring-aspects to dependency to enable spring-retry

### DIFF
--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -44,6 +44,10 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### spring-retry fix
When adding `spring-retry` via the `@EnableRetry` annotation in any data modules leveraging `synapse-data-mongodb`, the data module is unable to run integration tests due to the following error: 

> org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.aop.config.internalAutoProxyCreator': Initialization of bean failed; nested exception is java.lang.NoClassDefFoundError: org/aspectj/lang/annotation/Pointcut

Researching this issue shows the reason is because of missing spring dependencies and this was verified by examining the dependencies of other data-modules implementing `spring-retry` that are using various spring-dependencies that contain both `spring-aop` and `spring-aspects` such as the synapse-data-db2. 

`synapse-data-mongodb` already had `spring-aop`, `spring-aspects` just needed to be added. This was also tested on local using the previously failing implementation and the integration tests run as expected now.

Rather than having every implementing data-module include it in their build file it's better to fix it here in the synapse-base class