### PR TITLE
add database name to property file

### DIFF
--- a/data/data-samples/sample-data-cassandra-book/src/main/java/io/americanexpress/data/book/config/BookDataConfig.java
+++ b/data/data-samples/sample-data-cassandra-book/src/main/java/io/americanexpress/data/book/config/BookDataConfig.java
@@ -28,7 +28,7 @@ import org.springframework.data.cassandra.repository.config.EnableCassandraRepos
 public class BookDataConfig extends BaseCassandraDataConfig {
 
     public BookDataConfig(Environment environment) {
-        super(environment);
+        super(environment, "book");
     }
 
     @Override

--- a/data/data-samples/sample-data-cassandra-book/src/main/resources/data-book-application.properties
+++ b/data/data-samples/sample-data-cassandra-book/src/main/resources/data-book-application.properties
@@ -11,10 +11,10 @@
 #* or implied. See the License for the specific language governing permissions and limitations under
 #* the License.
 #*/
-spring.data.cassandra.keyspace-name=synapse
-spring.data.cassandra.local-datacenter=datacenter1
-spring.data.cassandra.port=9042
-spring.data.cassandra.contact-points=127.0.0.1
-spring.data.cassandra.schema-action=CREATE_IF_NOT_EXISTS
-#spring.data.cassandra.username = cassandra
-#spring.data.cassandra.password = cassandra
+spring.data.cassandra.book.keyspace-name=synapse
+spring.data.cassandra.book.local-datacenter=datacenter1
+spring.data.cassandra.book.port=9042
+spring.data.cassandra.book.contact-points=127.0.0.1
+spring.data.cassandra.book.schema-action=CREATE_IF_NOT_EXISTS
+#spring.data.cassandra.book.username = cassandra
+#spring.data.cassandra.book.password = cassandra

--- a/data/synapse-data-cassandra/README.md
+++ b/data/synapse-data-cassandra/README.md
@@ -13,6 +13,14 @@
         - spring.data.cassandra.contact-points
         - spring.data.cassandra.schema-action
 
+    - If needed to connect to multiple databases, a database name can be passed in the overloaded constructor of the `BaseCassandraDataConfig` class. 
+      the properties would need to be configured as:   
+        - spring.data.cassandra.<database-name>.keyspace-name
+        - spring.data.cassandra.<database-name>.local-datacenter
+        - spring.data.cassandra.<database-name>.port
+        - spring.data.cassandra.<database-name>.contact-points
+        - spring.data.cassandra.<database-name>.schema-action
+
     - An open to extension BaseEntity that contains the key identifier and the common auditing fields maintained by the Spring Data framework itself (createdBy,
       lastModifiedBy, createdDate, lastModifiedDate and version).
 

--- a/data/synapse-data-cassandra/src/main/java/io/americanexpress/synapse/data/cassandra/config/BaseCassandraDataConfig.java
+++ b/data/synapse-data-cassandra/src/main/java/io/americanexpress/synapse/data/cassandra/config/BaseCassandraDataConfig.java
@@ -29,43 +29,53 @@ import org.springframework.data.cassandra.repository.config.EnableCassandraRepos
 @EnableCassandraAuditing
 public abstract class BaseCassandraDataConfig extends AbstractCassandraConfiguration {
 
+    private static final String SPRING_DATA_CASSANDRA = "spring.data.cassandra.";
+
     private final Environment environment;
+
+    private final String propertiesPrefix;
 
     public BaseCassandraDataConfig(Environment environment) {
         this.environment = environment;
+        this.propertiesPrefix = SPRING_DATA_CASSANDRA;
+    }
+
+    public BaseCassandraDataConfig(Environment environment, String databaseName) {
+        this.environment = environment;
+        this.propertiesPrefix = SPRING_DATA_CASSANDRA + databaseName + ".";
     }
 
     @Override
     public SchemaAction getSchemaAction() {
-        return SchemaAction.valueOf(environment.getRequiredProperty("spring.data.cassandra.schema-action"));
+        return SchemaAction.valueOf(environment.getRequiredProperty(propertiesPrefix + "schema-action"));
     }
 
     @Override
     protected String getKeyspaceName() {
-        return environment.getRequiredProperty("spring.data.cassandra.keyspace-name");
+        return environment.getRequiredProperty(propertiesPrefix + "keyspace-name");
     }
 
     @Override
     protected String getContactPoints() {
-        return environment.getRequiredProperty("spring.data.cassandra.contact-points");
+        return environment.getRequiredProperty(propertiesPrefix + "contact-points");
     }
 
     @Override
     protected int getPort() {
-        return Integer.parseInt(environment.getRequiredProperty("spring.data.cassandra.port"));
+        return Integer.parseInt(environment.getRequiredProperty(propertiesPrefix + "port"));
     }
 
     @Override
     protected String getLocalDataCenter() {
-        return environment.getRequiredProperty("spring.data.cassandra.local-datacenter");
+        return environment.getRequiredProperty(propertiesPrefix + "local-datacenter");
     }
 
     protected String getUserName() {
-        return environment.getProperty("spring.data.cassandra.username");
+        return environment.getProperty(propertiesPrefix + "username");
     }
 
     protected String getPassword() {
-        return environment.getProperty("spring.data.cassandra.password");
+        return environment.getProperty(propertiesPrefix + "password");
     }
 
     @Override


### PR DESCRIPTION
This PR adds a database name to the cassandra db properties.
It will be useful when one app needs to connect to 2 different cassandra dbs.