### PR TITLE
extend crud repository

### DIFF
--- a/data/synapse-data-couchbase/src/main/java/io/americanexpress/synapse/data/couchbase/repository/BaseCrudCouchbaseRepository.java
+++ b/data/synapse-data-couchbase/src/main/java/io/americanexpress/synapse/data/couchbase/repository/BaseCrudCouchbaseRepository.java
@@ -1,6 +1,7 @@
 package io.americanexpress.synapse.data.couchbase.repository;
 
 import io.americanexpress.synapse.data.couchbase.entity.BaseCouchbaseEntity;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
@@ -8,5 +9,5 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  * @author Darien Liburd
  */
 @NoRepositoryBean
-public interface BaseCrudCouchbaseRepository<T extends BaseCouchbaseEntity, I> extends PagingAndSortingRepository<T, I> {
+public interface BaseCrudCouchbaseRepository<T extends BaseCouchbaseEntity, I> extends PagingAndSortingRepository<T, I>, CrudRepository<T, I> {
 }

--- a/data/synapse-data-couchbase/src/main/java/io/americanexpress/synapse/data/couchbase/repository/BaseReactiveCouchbaseRepository.java
+++ b/data/synapse-data-couchbase/src/main/java/io/americanexpress/synapse/data/couchbase/repository/BaseReactiveCouchbaseRepository.java
@@ -2,11 +2,12 @@ package io.americanexpress.synapse.data.couchbase.repository;
 
 import io.americanexpress.synapse.data.couchbase.entity.BaseCouchbaseEntity;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 /**
  * @author Darien Liburd
  */
 @NoRepositoryBean
-public interface BaseReactiveCouchbaseRepository<E extends BaseCouchbaseEntity, I> extends ReactiveSortingRepository<E, I> {
+public interface BaseReactiveCouchbaseRepository<E extends BaseCouchbaseEntity, I> extends ReactiveSortingRepository<E, I>, ReactiveCrudRepository<E, I> {
 }


### PR DESCRIPTION
This PR changes the couchbase module to extend the crud repository interface.

Since Spring Data 3, `PagingAndSortingRepository` no longer extends `CrudRepository`.

Document for reference:
https://github.com/spring-projects-experimental/spring-boot-migrator/issues/256