### PR TITLE
Update version to 0.4.10-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-graphql</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-delete</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-put</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>
     <build>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-client-rest</artifactId>
     <build>

--- a/archetype/synapse-archetype-data-postgres/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-data-postgres</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-delete</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-put</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-reactive-get</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-reactive-post</artifactId>
     <build>

--- a/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <artifactId>synapse-archetype-service-rest-reactive-put</artifactId>
     <build>

--- a/client/client-samples/pom.xml
+++ b/client/client-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/client-samples/sample-client-graphql-book/pom.xml
+++ b/client/client-samples/sample-client-graphql-book/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-graphql-book</artifactId>

--- a/client/client-samples/sample-client-reactive-football/pom.xml
+++ b/client/client-samples/sample-client-reactive-football/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>client-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/client-samples/sample-client-reactive-weather/pom.xml
+++ b/client/client-samples/sample-client-reactive-weather/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>client-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/client-samples/sample-client-weather/pom.xml
+++ b/client/client-samples/sample-client-weather/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>client-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/data-samples/pom.xml
+++ b/data/data-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/data-samples/sample-data-cassandra-book/pom.xml
+++ b/data/data-samples/sample-data-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-cassandra-reactive/pom.xml
+++ b/data/data-samples/sample-data-cassandra-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-db2-book/pom.xml
+++ b/data/data-samples/sample-data-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-mongodb-book/pom.xml
+++ b/data/data-samples/sample-data-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-mongodb-reactive/pom.xml
+++ b/data/data-samples/sample-data-mongodb-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-mssql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mssql-reactive-book/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mssql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mysql-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-mysql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-reactive-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-oracle-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-oracle-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/data-samples/sample-data-postgres-book/pom.xml
+++ b/data/data-samples/sample-data-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/data-samples/sample-data-redis-book/pom.xml
+++ b/data/data-samples/sample-data-redis-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-cassandra/pom.xml
+++ b/data/synapse-data-cassandra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>data</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-mssql/pom.xml
+++ b/data/synapse-data-mssql/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mssql</artifactId>

--- a/data/synapse-data-mysql/pom.xml
+++ b/data/synapse-data-mysql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-oracle/pom.xml
+++ b/data/synapse-data-oracle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/pom.xml
+++ b/function/function-samples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/sample-function-book-aws/pom.xml
+++ b/function/function-samples/sample-function-book-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/sample-function-greeter-aws/pom.xml
+++ b/function/function-samples/sample-function-greeter-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/sample-function-greeter-gcp/pom.xml
+++ b/function/function-samples/sample-function-greeter-gcp/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/sample-function-greeting/pom.xml
+++ b/function/function-samples/sample-function-greeting/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/function-samples/sample-function-rest-book/pom.xml
+++ b/function/function-samples/sample-function-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/function/synapse-function/pom.xml
+++ b/function/synapse-function/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.americanexpress.synapse</groupId>
     <artifactId>synapse</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.4.10-SNAPSHOT</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/pom.xml
+++ b/service/service-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/sample-service-db2-book/pom.xml
+++ b/service/service-samples/sample-service-db2-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-graphql-book/pom.xml
+++ b/service/service-samples/sample-service-graphql-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/sample-service-imperative-book/pom.xml
+++ b/service/service-samples/sample-service-imperative-book/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>service-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>service-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>service-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-reactive-mssql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mssql-book/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mssql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mysql-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-reactive-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-reactive-rest-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-rest-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-weather-client</artifactId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>sample-client-reactive-weather</artifactId>
-            <version>0.4.0-SNAPSHOT</version>
+            <version>0.4.10-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/service/service-samples/sample-service-rest-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-rest-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>service-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-rest-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-rest-mysql-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-rest-native-book/pom.xml
+++ b/service/service-samples/sample-service-rest-native-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/service-samples/sample-service-rest-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-rest-oracle-book/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/service-samples/sample-service-rest-postgres-book/pom.xml
+++ b/service/service-samples/sample-service-rest-postgres-book/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-postgres-book</artifactId>

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-reactive-rest/pom.xml
+++ b/service/synapse-service-reactive-rest/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/subscriber/pom.xml
+++ b/subscriber/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/subscriber/synapse-subscriber-kafka/pom.xml
+++ b/subscriber/synapse-subscriber-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>subscriber</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/utility/synapse-utility-cryptography/pom.xml
+++ b/utility/synapse-utility-cryptography/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>utility</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/utility/synapse-utility-date/pom.xml
+++ b/utility/synapse-utility-date/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>utility</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/utility/synapse-utility-number/pom.xml
+++ b/utility/synapse-utility-number/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>utility</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/utility/synapse-utility-telephone/pom.xml
+++ b/utility/synapse-utility-telephone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>utility</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Due to issues during last release, need to manually bump version to next snapshot 0.4.10