### PR TITLE
Version change for synapse data jpa and jdbc

### DIFF
--- a/data/synapse-data-jdbc/pom.xml
+++ b/data/synapse-data-jdbc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/data/synapse-data-jpa/pom.xml
+++ b/data/synapse-data-jpa/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
+        <version>0.4.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Bumping the verison of synapse-data-jpa and synapse-data-jdbc parent's version to 0.4.10-SNAPSHOT.