### PR TITLE
adding support for simple GET operation in rest and reactive rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.americanexpress.synapse</groupId>
     <artifactId>synapse</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.11-SNAPSHOT</version>
+    <version>0.4.13-SNAPSHOT</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseGetMonoReactiveController.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseGetMonoReactiveController.java
@@ -61,4 +61,32 @@ public abstract class BaseGetMonoReactiveController<O extends BaseServiceRespons
         logger.exit(responseEntity);
         return responseEntity;
     }
+
+
+    /**
+     * Get a single resource from the back end service.
+     *
+     * @param headers the headers
+     * @return response
+     */
+    @Operation(summary = "Reactive get mono", description = "Get resources reactively")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok"),
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+    })
+    @GetMapping("/")
+    public Mono<ResponseEntity<O>> read(@RequestHeader HttpHeaders headers) {
+        logger.entry(headers);
+
+        var serviceResponse = service.read(headers);
+        var responseEntity = serviceResponse
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.noContent().build());
+
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
 }

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/service/BaseGetMonoReactiveService.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/service/BaseGetMonoReactiveService.java
@@ -23,6 +23,28 @@ import reactor.core.publisher.Mono;
  */
 public abstract class BaseGetMonoReactiveService<O extends BaseServiceResponse> extends BaseService {
 
+
+    /**
+     * Retrieves one resource.
+     *
+     * @param headers headers
+     * @return a mono read response
+     */
+    public Mono<O> read(HttpHeaders headers) {
+        logger.entry(headers);
+        final var response = executeRead(headers);
+        logger.exit();
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     *
+     * @param headers headers
+     * @return a mono read response
+     */
+    protected abstract Mono<O> executeRead(HttpHeaders headers);
+
     /**
      * Retrieves one resource.
      *

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/BaseGetMonoController.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/controller/BaseGetMonoController.java
@@ -33,6 +33,24 @@ import org.springframework.web.bind.annotation.RequestHeader;
  */
 public class BaseGetMonoController<O extends BaseServiceResponse, S extends BaseGetMonoService<O>> extends BaseController<S> {
 
+
+    /**
+     * Read response entity.
+     *
+     * @param headers containing the HTTP headers from the consumer
+     * @return the response entity
+     */
+    @Operation(summary = "Read operation.", description = "Read resources.")
+    @GetMapping("/")
+    public ResponseEntity<O> read(@RequestHeader HttpHeaders headers) {
+        logger.entry(headers);
+
+        final O response = service.read(headers);
+        ResponseEntity<O> responseEntity = MonoResponseEntityCreator.create(response);
+
+        logger.exit(responseEntity);
+        return responseEntity;
+    }
     /**
      * Read response entity.
      *

--- a/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/service/BaseGetMonoService.java
+++ b/service/synapse-service-rest/src/main/java/io/americanexpress/synapse/service/rest/service/BaseGetMonoService.java
@@ -22,6 +22,31 @@ import org.springframework.http.HttpHeaders;
  */
 public abstract class BaseGetMonoService<O extends BaseServiceResponse> extends BaseService {
 
+
+    /**
+     * Gets a single resource.
+     *
+     * @param headers received from the controller
+     */
+    public O read(HttpHeaders headers) {
+
+        logger.entry(headers);
+
+        O response = executeRead(headers);
+
+        logger.exit(response);
+
+        return response;
+    }
+
+    /**
+     * Prototype for reading a resource.
+     * @param headers
+     * @return
+     */
+    protected abstract O executeRead(HttpHeaders headers);
+
+
     /**
      * Gets a single resource.
      *


### PR DESCRIPTION
This PR introduces an overloaded read() method in BaseGetMonoController to support simple GET requests without any path variables. The goal is to extend support for scenarios where a default or context-based resource needs to be fetched without requiring an ID.

- updated BaseGetMonoReactiveController