### PR TITLE
refactor: streamline Hibernate properties configuration in BasePostgresDataConfig

### DIFF
--- a/data/synapse-data-postgres/src/main/java/io/americanexpress/synapse/data/postgres/config/BasePostgresDataConfig.java
+++ b/data/synapse-data-postgres/src/main/java/io/americanexpress/synapse/data/postgres/config/BasePostgresDataConfig.java
@@ -14,7 +14,6 @@
 package io.americanexpress.synapse.data.postgres.config;
 
 import com.zaxxer.hikari.HikariDataSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -41,7 +40,6 @@ public abstract class BasePostgresDataConfig {
     /**
      * Used to acquire environment variables.
      */
-    @Autowired
     protected Environment environment;
 
     /**
@@ -49,7 +47,7 @@ public abstract class BasePostgresDataConfig {
      *
      * @param environment the environment
      */
-    public BasePostgresDataConfig(Environment environment) {
+    protected BasePostgresDataConfig(Environment environment) {
         this.environment = environment;
     }
 
@@ -64,7 +62,6 @@ public abstract class BasePostgresDataConfig {
         HikariDataSource dataSource = DataSourceBuilder.create().type(HikariDataSource.class).build();
         dataSource.setSchema(environment.getRequiredProperty("spring.jpa.properties.hibernate.default_schema"));
         dataSource.setLeakDetectionThreshold(2000);
-        dataSource.setDataSourceProperties(additionalHibernateSpringProperties());
         return dataSource;
     }
 
@@ -78,9 +75,6 @@ public abstract class BasePostgresDataConfig {
         properties.setProperty("hibernate.hbm2ddl.auto", environment.getRequiredProperty("hibernate.hbm2ddl.auto"));
         properties.setProperty("hibernate.show_sql", environment.getRequiredProperty("hibernate.show_sql"));
         properties.setProperty("hibernate.format_sql", environment.getRequiredProperty("hibernate.format_sql"));
-        properties.setProperty("spring.datasource.initialization-mode", environment.getRequiredProperty("spring.datasource.initialization-mode"));
-        properties.setProperty("hibernate.cache.use_query_cache", "true");
-        properties.setProperty("hibernate.cache.provider_class", "org.ehcache.hibernate.EhCacheProvider");
         return properties;
     }
 
@@ -94,6 +88,7 @@ public abstract class BasePostgresDataConfig {
         LocalContainerEntityManagerFactoryBean entityManagerFactoryBean = new LocalContainerEntityManagerFactoryBean();
         entityManagerFactoryBean.setDataSource(dataSource());
         entityManagerFactoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        entityManagerFactoryBean.setJpaProperties(additionalHibernateSpringProperties());
         setPackagesToScan(entityManagerFactoryBean);
         return entityManagerFactoryBean;
     }
@@ -101,7 +96,7 @@ public abstract class BasePostgresDataConfig {
     /**
      * Set the packages to Scan property to the entityManagerFactory.
      *
-     * @param entityManagerFactoryBean
+     * @param entityManagerFactoryBean the entity manager factory bean
      */
     protected abstract void setPackagesToScan(LocalContainerEntityManagerFactoryBean entityManagerFactoryBean);
 }


### PR DESCRIPTION
- Fix the synapse-data-postgres hibernate configuration
- Remove wrong property configurations
- Removed unnecessary Autowired annotation
- Downgrade the visibility of the constractor
