### PR TITLE
Update Maven Central Publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "0a:8a:6d:3a:22:28:74:a8:9e:a6:72:5d:bc:2b:aa:fe"
-      - run: mvn --settings ".circleci/settings.xml" -B release:clean release:prepare release:perform -P release -DscmCommentPrefix="[skip ci]"  # uses maven-release-plugin and central-publishing-maven-plugin
+      - run: mvn --settings ".circleci/settings.xml" --errors --activate-profiles release -define scmCommentPrefix="[skip ci]" release:clean release:prepare release:perform  # uses maven-release-plugin
 
   # RELEASE Deploy to Maven Central
   release-maven-central-deploy-job:
@@ -65,7 +65,7 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles release --define skipTests clean deploy
+      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
 
 #-------------------------------------------------------
 # Workflows that will schedule and execute jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --batch-mode dependency:go-offline
+      - run: mvn --batch-mode clean package
       - save_cache: # saves the project dependencies
           paths:
             - ~/.m2/repository
@@ -34,7 +34,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --batch-mode test
+      - run: mvn --batch-mode clean test
       - store_test_results: # We use this timing data to optimize the future runs
           path: target/surefire-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central
@@ -82,7 +82,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
 
 #-------------------------------------------------------
 # Workflows that will schedule and execute jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,15 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: synapse-{{ checksum "pom.xml" }}
-      - run: mvn -B clean package -DskipTests
+          keys:
+            - synapse-{{ checksum "pom.xml" }}
+            - synapse-
+      - run: mvn --batch-mode --define skipTests clean package
       - save_cache: # saves the project dependencies
           paths:
-            - ~/.m2
+            - ~/.m2/repository
           key: synapse-{{ checksum "pom.xml" }}
-      - run: mvn clean install -DskipTests
-      - run: mvn test
+      - run: mvn --batch-mode verify
       - store_test_results: # We use this timing data to optimize the future runs
           path: target/surefire-reports
 
@@ -29,7 +30,11 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn test
+      - restore_cache:
+          keys:
+            - synapse-{{ checksum "pom.xml" }}
+            - synapse-
+      - run: mvn --batch-mode test
       - store_test_results: # We use this timing data to optimize the future runs
           path: target/surefire-reports
 
@@ -40,7 +45,11 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
+      - restore_cache:
+          keys:
+            - synapse-{{ checksum "pom.xml" }}
+            - synapse-
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central
@@ -49,6 +58,10 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - synapse-{{ checksum "pom.xml" }}
+            - synapse-
       - run:
           name: Configure Git
           command: |
@@ -57,7 +70,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "0a:8a:6d:3a:22:28:74:a8:9e:a6:72:5d:bc:2b:aa:fe"
-      - run: mvn --settings ".circleci/settings.xml" --errors --activate-profiles release -define scmCommentPrefix="[skip ci]" release:clean release:prepare release:perform  # uses maven-release-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles release -define scmCommentPrefix="[skip ci]" release:clean release:prepare release:perform  # uses maven-release-plugin
 
   # RELEASE Deploy to Maven Central
   release-maven-central-deploy-job:
@@ -65,7 +78,11 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
+      - restore_cache:
+          keys:
+            - synapse-{{ checksum "pom.xml" }}
+            - synapse-
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
 
 #-------------------------------------------------------
 # Workflows that will schedule and execute jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,12 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --batch-mode clean package
+      - run: mvn --batch-mode --define style.color=always clean package
       - save_cache: # saves the project dependencies
           paths:
             - ~/.m2/repository
           key: synapse-{{ checksum "pom.xml" }}
-      - run: mvn --batch-mode verify
+      - run: mvn --batch-mode --define style.color=always verify
       - store_test_results: # We use this timing data to optimize the future runs
           path: target/surefire-reports
 
@@ -42,7 +42,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --batch-mode clean test
+      - run: mvn --batch-mode --define style.color=always clean test
       - store_test_results: # We use this timing data to optimize the future runs
           path: target/surefire-reports
 
@@ -58,7 +58,7 @@ jobs:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
       - configure-gpg
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --define style.color=always --errors --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central
@@ -80,7 +80,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "0a:8a:6d:3a:22:28:74:a8:9e:a6:72:5d:bc:2b:aa:fe"
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles release -define scmCommentPrefix="[skip ci]" release:clean release:prepare release:perform  # uses maven-release-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --define style.color=always --errors --activate-profiles release -define scmCommentPrefix="[skip ci]" release:clean release:prepare release:perform  # uses maven-release-plugin
 
   # RELEASE Deploy to Maven Central
   release-maven-central-deploy-job:
@@ -93,7 +93,7 @@ jobs:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
       - configure-gpg
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --define style.color=always --errors --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
 
 #-------------------------------------------------------
 # Workflows that will schedule and execute jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --batch-mode --define skipTests clean package
+      - run: mvn --batch-mode dependency:go-offline
       - save_cache: # saves the project dependencies
           paths:
             - ~/.m2/repository

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "0a:8a:6d:3a:22:28:74:a8:9e:a6:72:5d:bc:2b:aa:fe"
-      - run: mvn --settings ".circleci/settings.xml" -B release:clean release:prepare release:perform -P release -DscmCommentPrefix="[skip ci]"  # uses maven-release-plugin and nexus-staging-maven-plugin
+      - run: mvn --settings ".circleci/settings.xml" -B release:clean release:prepare release:perform -P release -DscmCommentPrefix="[skip ci]"  # uses maven-release-plugin and central-publishing-maven-plugin
 
   # RELEASE Deploy to Maven Central
   release-maven-central-deploy-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
       - configure-gpg
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn --settings ".circleci/settings.xml" -DskipTests clean deploy
+      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central
@@ -65,7 +65,7 @@ jobs:
       - image: cimg/openjdk:21.0
     steps:
       - checkout
-      - run: mvn --settings ".circleci/settings.xml" -DskipTests clean deploy -P release -e -X # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --errors --debug --activate-profiles release --define skipTests clean deploy
 
 #-------------------------------------------------------
 # Workflows that will schedule and execute jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,18 @@
 version: 2.1
 
+commands:
+  configure-gpg:
+    description: |
+      Configure GPG private keys.
+    steps:
+      - run:
+          command: echo $ORG_GRADLE_PROJECT_signingKey_base64 | base64 --decode | gpg --batch --no-tty --import --yes
+          name: Configure GPG private key for signing project artifacts in OSS Sonatype
+
 #-------------------------------------------------------
 # Jobs that will execute maven goals and git commands.
 #-------------------------------------------------------
 jobs:
-
   # Build and Test
   build-test-job:
     docker:
@@ -49,6 +57,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
+      - configure-gpg
       - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
@@ -62,6 +71,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
+      - configure-gpg
       - run:
           name: Configure Git
           command: |
@@ -82,6 +92,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
+      - configure-gpg
       - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles release --define skipTests clean deploy # uses maven-deploy-plugin
 
 #-------------------------------------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           keys:
             - synapse-{{ checksum "pom.xml" }}
             - synapse-
-      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
+      - run: mvn --settings ".circleci/settings.xml" --batch-mode --errors --debug --activate-profiles snapshot --define skipTests clean deploy # uses maven-deploy-plugin
 
 
   # SNAPSHOT to RELEASE Deploy to Maven Central

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -12,11 +12,6 @@
             <username>${env.GITHUB_USERNAME}</username>
             <password>${env.GITHUB_EMAIL}</password>
         </server>
-        <server>
-            <id>sign-artifacts</id>
-            <privateKey>${env.ORG_GRADLE_PROJECT_signingKey_base64}</privateKey>
-            <passphrase>${env.ORG_GRADLE_PROJECT_signingPassword}</passphrase>
-        </server>
     </servers>
     <profiles>
         <profile>
@@ -25,8 +20,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <gpg.privatekey>${env.ORG_GRADLE_PROJECT_signingKey_base64}</gpg.privatekey>
-                <gpg.passphrase>${env.ORG_GRADLE_PROJECT_signingPassword}</gpg.passphrase>
+                <gpg.keyEnvName>ORG_GRADLE_PROJECT_signingKey_base64</gpg.keyEnvName>
+                <gpg.passphraseEnvName>ORG_GRADLE_PROJECT_signingPassword</gpg.passphraseEnvName>
             </properties>
         </profile>
     </profiles>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -2,11 +2,6 @@
 <settings xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
-<!--        <server>-->
-<!--            <id>central</id>-->
-<!--            <username>${env.SONATYPE_MAVEN_CENTRAL_USERNAME}</username>-->
-<!--            <password>${env.SONATYPE_MAVEN_CENTRAL_PASSWORD}</password>-->
-<!--        </server>-->
         <server>
             <id>central</id>
             <username>${env.MAVEN_CENTRAL_USERNAME}</username>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -2,10 +2,15 @@
 <settings xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
+<!--        <server>-->
+<!--            <id>central</id>-->
+<!--            <username>${env.SONATYPE_MAVEN_CENTRAL_USERNAME}</username>-->
+<!--            <password>${env.SONATYPE_MAVEN_CENTRAL_PASSWORD}</password>-->
+<!--        </server>-->
         <server>
             <id>central</id>
-            <username>${env.SONATYPE_MAVEN_CENTRAL_USERNAME}</username>
-            <password>${env.SONATYPE_MAVEN_CENTRAL_PASSWORD}</password>
+            <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+            <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
         </server>
         <server>
             <id>github</id>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -20,7 +20,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <gpg.keyEnvName>ORG_GRADLE_PROJECT_signingKey_base64</gpg.keyEnvName>
                 <gpg.passphraseEnvName>ORG_GRADLE_PROJECT_signingPassword</gpg.passphraseEnvName>
             </properties>
         </profile>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -3,7 +3,7 @@
           xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <servers>
         <server>
-            <id>ossrh</id>
+            <id>central</id>
             <username>${env.SONATYPE_MAVEN_CENTRAL_USERNAME}</username>
             <password>${env.SONATYPE_MAVEN_CENTRAL_PASSWORD}</password>
         </server>
@@ -20,7 +20,7 @@
     </servers>
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -25,7 +25,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <gpg.executable>gpg2</gpg.executable>
                 <gpg.privatekey>${env.ORG_GRADLE_PROJECT_signingKey_base64}</gpg.privatekey>
                 <gpg.passphrase>${env.ORG_GRADLE_PROJECT_signingPassword}</gpg.passphrase>
             </properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>api</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-api-rest-imperative</artifactId>

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-api-rest-imperative</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>
@@ -46,7 +46,6 @@
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>synapse-framework-test</artifactId>
         </dependency>
-
 
         <!--External Dependencies-->
         <!-- Jakarta -->
@@ -74,7 +73,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
-
 
         <!--Spring Boot-->
         <dependency>

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-api-rest-reactive</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-api-rest-reactive</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>archetype</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>archetype</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-graphql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-graphql</artifactId>

--- a/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-delete</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-get</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-post</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-put</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest</artifactId>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-client-rest</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-client-rest/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-data-postgres/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-data-postgres</artifactId>

--- a/archetype/synapse-archetype-data-postgres/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-data-postgres</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-data-postgres/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-data-postgres/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/src/main/resources/archetype-resources/pom.xml
@@ -11,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-delete</artifactId>

--- a/archetype/synapse-archetype-service-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/pom.xml
@@ -1,25 +1,28 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2020 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
-   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-   in compliance with the License. You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software distributed under the License
-   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-   or implied. See the License for the specific language governing permissions and limitations under
-   the License.
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-delete</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,19 +11,21 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <version>${version}</version>
+
     <properties>
-        <synapse.version>0.3.32-SNAPSHOT</synapse.version>
+        <synapse.version>${revision}</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.americanexpress.synapse</groupId>
@@ -62,6 +63,7 @@
             <version>${junit.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-delete/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <version>${version}</version>
 
     <properties>
-        <synapse.version>${revision}</synapse.version>
+        <synapse.version>0.4.18-SNAPSHOT</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-get</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,15 +11,14 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/src/main/resources/archetype-resources/pom.xml
@@ -18,7 +18,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-post</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,19 +11,21 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <version>${version}</version>
+
     <properties>
-        <synapse.version>0.3.32-SNAPSHOT</synapse.version>
+        <synapse.version>${revision}</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.americanexpress.synapse</groupId>
@@ -62,6 +63,7 @@
             <version>${junit.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <version>${version}</version>
 
     <properties>
-        <synapse.version>${revision}</synapse.version>
+        <synapse.version>0.4.18-SNAPSHOT</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-put</artifactId>

--- a/archetype/synapse-archetype-service-rest-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-put</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-reactive-get</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,15 +11,13 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
@@ -1,22 +1,28 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software distributed under the License
     is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-reactive-post</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
@@ -1,27 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software distributed under the License
     is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <version>${version}</version>
+
     <properties>
-        <synapse.version>0.3.32-SNAPSHOT</synapse.version>
+        <synapse.version>${revision}</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.americanexpress.synapse</groupId>
@@ -59,6 +63,7 @@
             <version>${junit.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <version>${version}</version>
 
     <properties>
-        <synapse.version>${revision}</synapse.version>
+        <synapse.version>0.4.18-SNAPSHOT</synapse.version>
         <java.version>${javaVersion}</java.version>
         <junit.version>1.6.2</junit.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-put</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
@@ -11,14 +11,18 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
+
     <artifactId>synapse-archetype-service-rest-reactive-put</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <build>
         <plugins>
             <plugin>

--- a/archetype/synapse-archetype-service-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>${revision}</synapse.version>
+		<synapse.version>0.4.18-SNAPSHOT</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/archetype/synapse-archetype-service-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/src/main/resources/archetype-resources/pom.xml
@@ -1,23 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software distributed under the License
     is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
 	<properties>
-		<synapse.version>0.3.32-SNAPSHOT</synapse.version>
+		<synapse.version>${revision}</synapse.version>
 		<java.version>${javaVersion}</java.version>
 		<junit.version>1.6.2</junit.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/client/client-samples/pom.xml
+++ b/client/client-samples/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>client-samples</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/client/client-samples/pom.xml
+++ b/client/client-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>client-samples</artifactId>

--- a/client/client-samples/sample-client-graphql-book/pom.xml
+++ b/client/client-samples/sample-client-graphql-book/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sample-client-graphql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/client/client-samples/sample-client-graphql-book/pom.xml
+++ b/client/client-samples/sample-client-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-graphql-book</artifactId>

--- a/client/client-samples/sample-client-reactive-football/pom.xml
+++ b/client/client-samples/sample-client-reactive-football/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-reactive-football</artifactId>

--- a/client/client-samples/sample-client-reactive-football/pom.xml
+++ b/client/client-samples/sample-client-reactive-football/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>client-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>client-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-client-reactive-football</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/client/client-samples/sample-client-reactive-weather/pom.xml
+++ b/client/client-samples/sample-client-reactive-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-reactive-weather</artifactId>

--- a/client/client-samples/sample-client-reactive-weather/pom.xml
+++ b/client/client-samples/sample-client-reactive-weather/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>client-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>client-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-client-reactive-weather</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/client/client-samples/sample-client-weather/pom.xml
+++ b/client/client-samples/sample-client-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-weather</artifactId>

--- a/client/client-samples/sample-client-weather/pom.xml
+++ b/client/client-samples/sample-client-weather/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>client-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>client-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-client-weather</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>client</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>client</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-client-graphql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies -->
     <dependencies>

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-graphql</artifactId>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-rest</artifactId>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-client-rest</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies -->
     <dependencies>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-client-soap</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>
@@ -74,6 +75,5 @@
             </plugin>
         </plugins>
     </reporting>
-
 
 </project>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-soap</artifactId>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-client-test</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-test</artifactId>

--- a/data/data-samples/pom.xml
+++ b/data/data-samples/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>data-samples</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/data/data-samples/pom.xml
+++ b/data/data-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-samples</artifactId>

--- a/data/data-samples/sample-data-cassandra-book/pom.xml
+++ b/data/data-samples/sample-data-cassandra-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-cassandra-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-cassandra-book/pom.xml
+++ b/data/data-samples/sample-data-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-cassandra-book</artifactId>

--- a/data/data-samples/sample-data-cassandra-reactive/pom.xml
+++ b/data/data-samples/sample-data-cassandra-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-cassandra-reactive</artifactId>

--- a/data/data-samples/sample-data-cassandra-reactive/pom.xml
+++ b/data/data-samples/sample-data-cassandra-reactive/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-cassandra-reactive</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-db2-book/pom.xml
+++ b/data/data-samples/sample-data-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-db2-book</artifactId>

--- a/data/data-samples/sample-data-db2-book/pom.xml
+++ b/data/data-samples/sample-data-db2-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-data-db2-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-mongodb-book/pom.xml
+++ b/data/data-samples/sample-data-mongodb-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-mongodb-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-mongodb-book/pom.xml
+++ b/data/data-samples/sample-data-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mongodb-book</artifactId>

--- a/data/data-samples/sample-data-mongodb-reactive/pom.xml
+++ b/data/data-samples/sample-data-mongodb-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mongodb-reactive</artifactId>

--- a/data/data-samples/sample-data-mongodb-reactive/pom.xml
+++ b/data/data-samples/sample-data-mongodb-reactive/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-mongodb-reactive</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-mssql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mssql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mssql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mssql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mssql-reactive-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -14,13 +13,15 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sample-data-mssql-reactive-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-mysql-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mysql-book</artifactId>

--- a/data/data-samples/sample-data-mysql-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-mysql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/data/data-samples/sample-data-mysql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mysql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mysql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-reactive-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-mysql-reactive-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/data/data-samples/sample-data-oracle-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-book</artifactId>

--- a/data/data-samples/sample-data-oracle-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-oracle-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/data/data-samples/sample-data-oracle-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-oracle-reactive-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/data/data-samples/sample-data-oracle-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-book</artifactId>

--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-oracle-reactive-cp-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-cp-book</artifactId>

--- a/data/data-samples/sample-data-postgres-book/pom.xml
+++ b/data/data-samples/sample-data-postgres-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-data-postgres-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/data-samples/sample-data-postgres-book/pom.xml
+++ b/data/data-samples/sample-data-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-postgres-book</artifactId>

--- a/data/data-samples/sample-data-redis-book/pom.xml
+++ b/data/data-samples/sample-data-redis-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>data-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>data-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-data-redis-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse dependencies -->

--- a/data/data-samples/sample-data-redis-book/pom.xml
+++ b/data/data-samples/sample-data-redis-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-redis-book</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>data</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/data/synapse-data-cassandra/pom.xml
+++ b/data/synapse-data-cassandra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-cassandra</artifactId>

--- a/data/synapse-data-cassandra/pom.xml
+++ b/data/synapse-data-cassandra/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-cassandra</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-couchbase</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-couchbase</artifactId>

--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-db2</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-db2</artifactId>

--- a/data/synapse-data-jdbc/pom.xml
+++ b/data/synapse-data-jdbc/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-jdbc</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-jdbc/pom.xml
+++ b/data/synapse-data-jdbc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-jdbc</artifactId>

--- a/data/synapse-data-jpa/pom.xml
+++ b/data/synapse-data-jpa/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-jpa</artifactId>

--- a/data/synapse-data-jpa/pom.xml
+++ b/data/synapse-data-jpa/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-jpa</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>data</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
+        <artifactId>data</artifactId>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-mongodb</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -83,6 +84,5 @@
             </plugin>
         </plugins>
     </reporting>
-
 
 </project>

--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mongodb</artifactId>

--- a/data/synapse-data-mssql/pom.xml
+++ b/data/synapse-data-mssql/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -14,13 +13,15 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>synapse-data-mssql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-mssql/pom.xml
+++ b/data/synapse-data-mssql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mssql</artifactId>

--- a/data/synapse-data-mysql/pom.xml
+++ b/data/synapse-data-mysql/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-mysql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-mysql/pom.xml
+++ b/data/synapse-data-mysql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mysql</artifactId>

--- a/data/synapse-data-oracle/pom.xml
+++ b/data/synapse-data-oracle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-oracle</artifactId>

--- a/data/synapse-data-oracle/pom.xml
+++ b/data/synapse-data-oracle/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-oracle</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2019 American Express Travel Related Services Company, Inc.
+    Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-postgres</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-postgres</artifactId>

--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-redis</artifactId>

--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-data-redis</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Spring Dependencies -->

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>framework</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework</artifactId>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-framework-api-docs</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-api-docs</artifactId>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-exception</artifactId>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-framework-exception</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-framework-logging</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-logging</artifactId>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-framework-test</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-test</artifactId>

--- a/function/function-samples/pom.xml
+++ b/function/function-samples/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>function-samples</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/function/function-samples/pom.xml
+++ b/function/function-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>function-samples</artifactId>

--- a/function/function-samples/sample-function-book-aws/pom.xml
+++ b/function/function-samples/sample-function-book-aws/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-function-book-aws</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/function/function-samples/sample-function-book-aws/pom.xml
+++ b/function/function-samples/sample-function-book-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-book-aws</artifactId>

--- a/function/function-samples/sample-function-greeter-aws/pom.xml
+++ b/function/function-samples/sample-function-greeter-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeter-aws</artifactId>

--- a/function/function-samples/sample-function-greeter-aws/pom.xml
+++ b/function/function-samples/sample-function-greeter-aws/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-function-greeter-aws</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/function/function-samples/sample-function-greeter-gcp/pom.xml
+++ b/function/function-samples/sample-function-greeter-gcp/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeter-gcp</artifactId>

--- a/function/function-samples/sample-function-greeter-gcp/pom.xml
+++ b/function/function-samples/sample-function-greeter-gcp/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-function-greeter-gcp</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/function/function-samples/sample-function-greeting/pom.xml
+++ b/function/function-samples/sample-function-greeting/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeting</artifactId>

--- a/function/function-samples/sample-function-greeting/pom.xml
+++ b/function/function-samples/sample-function-greeting/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-function-greeting</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/function/function-samples/sample-function-rest-book/pom.xml
+++ b/function/function-samples/sample-function-rest-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-function-rest-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/function/function-samples/sample-function-rest-book/pom.xml
+++ b/function/function-samples/sample-function-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-rest-book</artifactId>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>function</artifactId>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>function</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/function/synapse-function/pom.xml
+++ b/function/synapse-function/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-function</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>
@@ -81,8 +81,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
         </dependency>
-
-
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/function/synapse-function/pom.xml
+++ b/function/synapse-function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-function</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>synapse</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
-    <version>${revision}</version>
+    <version>0.4.18-SNAPSHOT</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise
@@ -53,8 +53,6 @@
     </licenses>
 
     <properties>
-        <revision>0.4.18-SNAPSHOT</revision>
-
         <!--Java-->
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -981,8 +979,6 @@
                     <version>3.1.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <useReleaseProfile>false</useReleaseProfile>
-                        <releaseProfiles>release</releaseProfiles>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -998,12 +998,7 @@
                                 <goal>sign</goal>
                             </goals>
                             <configuration>
-                                <gpgArguments>
-                                    <arg>--batch</arg>
-                                    <arg>--no-tty</arg>
-                                    <arg>--pinentry-mode</arg>
-                                    <arg>loopback</arg>
-                                </gpgArguments>
+                                <bestPractices>true</bestPractices>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1091,17 +1091,19 @@
             <build>
                 <pluginManagement>
                     <plugins>
+
+                        <!-- Sonatype Central Publishing Plugin -->
                         <plugin>
-                            <groupId>org.sonatype.plugins</groupId>
-                            <artifactId>nexus-staging-maven-plugin</artifactId>
-                            <version>1.7.0</version>
+                            <groupId>org.sonatype.central</groupId>
+                            <artifactId>central-publishing-maven-plugin</artifactId>
+                            <version>0.8.0</version>
                             <extensions>true</extensions>
                             <configuration>
-                                <serverId>ossrh</serverId>
-                                <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                                <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                                <publishingServerId>central</publishingServerId>
+                                <autoPublish>true</autoPublish>
                             </configuration>
                         </plugin>
+
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-release-plugin</artifactId>
@@ -1110,7 +1112,7 @@
                                 <autoVersionSubmodules>true</autoVersionSubmodules>
                                 <useReleaseProfile>false</useReleaseProfile>
                                 <releaseProfiles>release</releaseProfiles>
-                                <goals>deploy nexus-staging:release</goals>
+                                <goals>deploy</goals>
                             </configuration>
                         </plugin>
                         <plugin>
@@ -1167,23 +1169,6 @@
                 </pluginManagement>
             </build>
         </profile>
-
-        <!--Profile staging-->
-        <profile>
-            <id>staging</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <distributionManagement>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
-        </profile>
     </profiles>
 
     <!--Repositories-->
@@ -1205,6 +1190,7 @@
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
+
     <repositories>
         <repository>
             <id>spring-release</id>
@@ -1231,31 +1217,6 @@
             </snapshots>
         </repository>
     </repositories>
-
-
-    <!--Use for Maven Deploy Plugin-->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
-
-    <!--
-    Maven Central Distribution Urls:
-
-    Snapshot Distribution Location
-            - https://s01.oss.sonatype.org/content/repositories/snapshots/
-    Staging Distribution Location:
-            - https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
-    Release Distribution Location:
-            - https://s01.oss.sonatype.org/content/repositories/releases/
-    -->
-
 
     <scm>
         <url>https://github.com/americanexpress/synapse</url>

--- a/pom.xml
+++ b/pom.xml
@@ -776,6 +776,19 @@
     <build>
         <pluginManagement>
             <plugins>
+
+                <!-- Sonatype Central Publishing Plugin -->
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.springdoc</groupId>
                     <artifactId>springdoc-openapi-maven-plugin</artifactId>
@@ -1034,6 +1047,10 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.18.0</version>
@@ -1091,19 +1108,6 @@
             <build>
                 <pluginManagement>
                     <plugins>
-
-                        <!-- Sonatype Central Publishing Plugin -->
-                        <plugin>
-                            <groupId>org.sonatype.central</groupId>
-                            <artifactId>central-publishing-maven-plugin</artifactId>
-                            <version>0.8.0</version>
-                            <extensions>true</extensions>
-                            <configuration>
-                                <publishingServerId>central</publishingServerId>
-                                <autoPublish>true</autoPublish>
-                            </configuration>
-                        </plugin>
-
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -999,10 +999,11 @@
                             </goals>
                             <configuration>
                                 <gpgArguments>
+                                    <arg>--batch</arg>
+                                    <arg>--no-tty</arg>
                                     <arg>--pinentry-mode</arg>
                                     <arg>loopback</arg>
                                 </gpgArguments>
-                                <passphraseServerId>sign-artifacts</passphraseServerId>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -753,6 +753,17 @@
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
                 <version>3.10.8</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.9</version>
             </dependency>
 
             <!--Hibernate-->

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kotlin.version>2.1.21</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.3</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.4</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.0</spring-cloud-framework.version>
 
         <!--Springdoc-->
@@ -78,11 +78,11 @@
         <spring-boot-graphql.version>15.1.0</spring-boot-graphql.version>
         <spring-boot-graphiql.version>11.1.0</spring-boot-graphiql.version>
 
-        <!--Mock Dependency Versions-->
-        <mockito.version>5.15.2</mockito.version>
+        <!--Mockito Versions-->
+        <mockito.version>5.18.0</mockito.version>
 
         <!--JUnit Versions-->
-        <junit.version>5.13.1</junit.version>
+        <junit.version>5.13.4</junit.version>
 
         <!--Logging-->
         <log4j.version>2.24.3</log4j.version>
@@ -94,9 +94,6 @@
         <!--Db2-->
         <db2-db2jcc4.version>11.5</db2-db2jcc4.version>
         <db2-jcc.version>11.5.0.0</db2-jcc.version>
-
-        <!--TestContainers-->
-        <testcontainers.version>1.20.6</testcontainers.version>
     </properties>
 
     <modules>
@@ -802,6 +799,14 @@
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
                 <version>1.47.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,25 @@
         </developer>
     </developers>
 
+    <scm>
+        <url>https://github.com/americanexpress/synapse</url>
+        <connection>scm:git:https://github.com/americanexpress/synapse.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/americanexpress/synapse.git</developerConnection>
+        <tag>synapse-0.4.18</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/americanexpress/synapse/issues</url>
+    </issueManagement>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>./LICENSE</url>
+        </license>
+    </licenses>
+
     <properties>
         <revision>0.4.18-SNAPSHOT</revision>
 
@@ -371,65 +390,37 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <!--Samples-->
+            <!-- Client Samples -->
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>client-samples</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-client-graphql-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-client-reactive-football</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-client-reactive-weather</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-client-weather</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Data Samples -->
             <dependency>
                 <groupId>io.americanexpress.synapse</groupId>
                 <artifactId>data-samples</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>service-samples</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>function-samples</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-function-greeting</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-function-greeter-aws</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-function-greeter-gcp</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-service-graphql-book</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-service-imperative-book</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-service-reactive-cassandra-book</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-service-rest-book</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <!--            <dependency>
-                            <groupId>io.americanexpress.synapse</groupId>
-                            <artifactId>sample-service-rest-native-book</artifactId>
-                            <version>${project.version}</version>
-                        </dependency>-->
-            <dependency>
-                <groupId>io.americanexpress.synapse</groupId>
-                <artifactId>sample-service-rest-cassandra-book</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -497,8 +488,129 @@
                 <artifactId>sample-data-redis-book</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!--External Dependencies-->
 
+            <!-- Function Samples -->
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>function-samples</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-function-book-aws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-function-greeter-aws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-function-greeter-gcp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-function-greeting</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-function-rest-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Service Samples -->
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>service-samples</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-db2-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-graphql-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-imperative-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-cassandra-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-mongodb-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-mssql-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-mysql-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-oracle-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-oracle-cp-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-rest-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-reactive-weather-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-rest-cassandra-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-rest-mysql-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-rest-native-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-rest-oracle-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.americanexpress.synapse</groupId>
+                <artifactId>sample-service-rest-postgres-book</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!--External Dependencies-->
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-rules</artifactId>
@@ -778,7 +890,6 @@
     <build>
         <pluginManagement>
             <plugins>
-
                 <!-- Sonatype Central Publishing Plugin -->
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
@@ -791,6 +902,111 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.11.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <failOnError>false</failOnError> <!-- TODO: Resolve JavaDoc errors and remove this -->
+                        <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.18.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-maven-plugin</artifactId>
+                    <version>${kotlin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <sourceDirs>
+                                    <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                                </sourceDirs>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>test-compile</id>
+                            <phase>test-compile</phase>
+                            <goals>
+                                <goal>test-compile</goal>
+                            </goals>
+                            <configuration>
+                                <sourceDirs>
+                                    <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                    <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                                </sourceDirs>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <jvmTarget>${java.version}</jvmTarget>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <releaseProfiles>release</releaseProfiles>
+                        <goals>deploy</goals>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.7</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                            <configuration>
+                                <gpgArguments>
+                                    <arg>--pinentry-mode</arg>
+                                    <arg>loopback</arg>
+                                </gpgArguments>
+                                <passphraseServerId>sign-artifacts</passphraseServerId>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.springdoc</groupId>
                     <artifactId>springdoc-openapi-maven-plugin</artifactId>
@@ -1047,200 +1263,62 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+
+
+
         <plugins>
             <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.18.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmTarget>${java.version}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>
 
     <!--Profiles-->
     <profiles>
+        <profile>
+            <id>snapshot</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <!--Profile release-->
         <profile>
             <id>release</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-release-plugin</artifactId>
-                            <version>3.1.1</version>
-                            <configuration>
-                                <autoVersionSubmodules>true</autoVersionSubmodules>
-                                <useReleaseProfile>false</useReleaseProfile>
-                                <releaseProfiles>release</releaseProfiles>
-                                <goals>deploy</goals>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-gpg-plugin</artifactId>
-                            <version>3.2.7</version>
-                            <executions>
-                                <execution>
-                                    <id>sign-artifacts</id>
-                                    <phase>verify</phase>
-                                    <goals>
-                                        <goal>sign</goal>
-                                    </goals>
-                                    <configuration>
-                                        <gpgArguments>
-                                            <arg>--pinentry-mode</arg>
-                                            <arg>loopback</arg>
-                                        </gpgArguments>
-                                        <passphraseServerId>sign-artifacts</passphraseServerId>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>3.11.1</version>
-                            <executions>
-                                <execution>
-                                    <id>attach-javadocs</id>
-                                    <goals>
-                                        <goal>jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-source-plugin</artifactId>
-                            <version>3.3.1</version>
-                            <executions>
-                                <execution>
-                                    <id>attach-sources</id>
-                                    <goals>
-                                        <goal>jar-no-fork</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>
-
-    <!--Repositories-->
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-release</id>
-            <name>Spring release</name>
-            <url>https://repo.spring.io/release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>spring-snapshot</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <repositories>
-        <repository>
-            <id>spring-release</id>
-            <name>Spring release</name>
-            <url>https://repo.spring.io/release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-snapshot</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <scm>
-        <url>https://github.com/americanexpress/synapse</url>
-        <connection>scm:git:https://github.com/americanexpress/synapse.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/americanexpress/synapse.git</developerConnection>
-        <tag>synapse-0.1.0</tag>
-    </scm>
-
-    <issueManagement>
-        <system>GitHub Issues</system>
-        <url>https://github.com/americanexpress/synapse/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>The Apache License, Version 2.0</name>
-            <url>./LICENSE</url>
-        </license>
-    </licenses>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -753,17 +753,6 @@
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
                 <version>3.10.8</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.glassfish.jaxb</groupId>
-                        <artifactId>jaxb-runtime</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.9</version>
             </dependency>
 
             <!--Hibernate-->

--- a/pom.xml
+++ b/pom.xml
@@ -1289,10 +1289,10 @@
             <id>snapshot</id>
             <build>
                 <plugins>
-<!--                    <plugin>-->
-<!--                        <groupId>org.apache.maven.plugins</groupId>-->
-<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
-<!--                    </plugin>-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
@@ -1309,10 +1309,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
                     </plugin>
-<!--                    <plugin>-->
-<!--                        <groupId>org.apache.maven.plugins</groupId>-->
-<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
-<!--                    </plugin>-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,12 +12,13 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>io.americanexpress.synapse</groupId>
     <artifactId>synapse</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
-    <version>0.4.18-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise
@@ -34,6 +34,8 @@
     </developers>
 
     <properties>
+        <revision>0.4.18-SNAPSHOT</revision>
+
         <!--Java-->
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -1289,10 +1289,10 @@
             <id>snapshot</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                    </plugin>
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                    </plugin>-->
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
@@ -1309,10 +1309,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                    </plugin>
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                    </plugin>-->
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>publisher</artifactId>

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>publisher</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-publisher-kafka</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-publisher-kafka</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>service</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>service</artifactId>

--- a/service/service-samples/pom.xml
+++ b/service/service-samples/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>service-samples</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/service/service-samples/pom.xml
+++ b/service/service-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-samples</artifactId>

--- a/service/service-samples/sample-service-db2-book/pom.xml
+++ b/service/service-samples/sample-service-db2-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-db2-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/service-samples/sample-service-db2-book/pom.xml
+++ b/service/service-samples/sample-service-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-db2-book</artifactId>

--- a/service/service-samples/sample-service-graphql-book/pom.xml
+++ b/service/service-samples/sample-service-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-graphql-book</artifactId>

--- a/service/service-samples/sample-service-graphql-book/pom.xml
+++ b/service/service-samples/sample-service-graphql-book/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -14,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-service-graphql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/service-samples/sample-service-imperative-book/pom.xml
+++ b/service/service-samples/sample-service-imperative-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>service-samples</artifactId>
         <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
+        <artifactId>service-samples</artifactId>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-service-imperative-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!-- Dependencies -->
     <dependencies>

--- a/service/service-samples/sample-service-imperative-book/pom.xml
+++ b/service/service-samples/sample-service-imperative-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-imperative-book</artifactId>

--- a/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>service-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-service-reactive-cassandra-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!--Synapse-->

--- a/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mongodb-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>service-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-service-reactive-mongodb-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/service-samples/sample-service-reactive-mssql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mssql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mssql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mssql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mssql-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -14,13 +13,15 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sample-service-reactive-mssql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/service-samples/sample-service-reactive-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mysql-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-reactive-mysql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/service/service-samples/sample-service-reactive-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mysql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-reactive-oracle-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/service/service-samples/sample-service-reactive-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-cp-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-reactive-oracle-cp-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/service/service-samples/sample-service-reactive-rest-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-rest-book</artifactId>

--- a/service/service-samples/sample-service-reactive-rest-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-rest-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-service-reactive-rest-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-weather-client</artifactId>

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -14,13 +13,15 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sample-service-reactive-weather-client</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>sample-client-reactive-weather</artifactId>
-            <version>0.4.18-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/service/service-samples/sample-service-rest-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-rest-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-rest-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-rest-cassandra-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>service-samples</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>service-samples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>sample-service-rest-cassandra-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/service-samples/sample-service-rest-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-rest-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-mysql-book</artifactId>

--- a/service/service-samples/sample-service-rest-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-rest-mysql-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-rest-mysql-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/service/service-samples/sample-service-rest-native-book/pom.xml
+++ b/service/service-samples/sample-service-rest-native-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -12,16 +11,17 @@
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
         <version>0.4.11-SNAPSHOT</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>sample-service-rest-native-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <!-- This property is needed to prevent a conflict between various build plugins -->

--- a/service/service-samples/sample-service-rest-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-rest-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-oracle-book</artifactId>

--- a/service/service-samples/sample-service-rest-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-rest-oracle-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>sample-service-rest-oracle-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!-- Synapse -->

--- a/service/service-samples/sample-service-rest-postgres-book/pom.xml
+++ b/service/service-samples/sample-service-rest-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-postgres-book</artifactId>

--- a/service/service-samples/sample-service-rest-postgres-book/pom.xml
+++ b/service/service-samples/sample-service-rest-postgres-book/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -14,13 +13,15 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sample-service-rest-postgres-book</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -1,24 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software distributed under the License
     is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
     or implied. See the License for the specific language governing permissions and limitations under
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-graphql</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!--Synapse-->

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-graphql</artifactId>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-imperative</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-imperative</artifactId>

--- a/service/synapse-service-reactive-rest/pom.xml
+++ b/service/synapse-service-reactive-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-reactive-rest</artifactId>

--- a/service/synapse-service-reactive-rest/pom.xml
+++ b/service/synapse-service-reactive-rest/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-reactive-rest</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-reactive</artifactId>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-reactive</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-rest</artifactId>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-rest</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>
@@ -46,7 +46,6 @@
             <groupId>io.americanexpress.synapse</groupId>
             <artifactId>synapse-framework-test</artifactId>
         </dependency>
-
 
         <!--External Dependencies-->
         <!-- Jakarta -->
@@ -78,7 +77,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
         </dependency>
-
 
         <!--Spring Boot-->
         <dependency>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-service-test</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-test</artifactId>

--- a/subscriber/pom.xml
+++ b/subscriber/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>subscriber</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/subscriber/pom.xml
+++ b/subscriber/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>subscriber</artifactId>

--- a/subscriber/synapse-subscriber-kafka/pom.xml
+++ b/subscriber/synapse-subscriber-kafka/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>subscriber</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-subscriber-kafka</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>

--- a/subscriber/synapse-subscriber-kafka/pom.xml
+++ b/subscriber/synapse-subscriber-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>subscriber</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-subscriber-kafka</artifactId>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>utility</artifactId>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,14 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>utility</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <!--Modules-->

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2020 American Express Travel Related Services Company, Inc.
 
@@ -13,15 +12,16 @@
     the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.18-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>synapse-utilities-common</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <!--Dependencies-->
     <dependencies>
@@ -123,7 +123,6 @@
         </dependency>
     </dependencies>
 
-
     <build>
         <plugins>
             <plugin>
@@ -159,5 +158,3 @@
         </plugins>
     </reporting>
 </project>
-
-

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utilities-common</artifactId>

--- a/utility/synapse-utility-cryptography/pom.xml
+++ b/utility/synapse-utility-cryptography/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-cryptography</artifactId>

--- a/utility/synapse-utility-cryptography/pom.xml
+++ b/utility/synapse-utility-cryptography/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>utility</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>utility</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>synapse-utility-cryptography</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <!--Synapse-->

--- a/utility/synapse-utility-date/pom.xml
+++ b/utility/synapse-utility-date/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>utility</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>utility</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>synapse-utility-date</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/utility/synapse-utility-date/pom.xml
+++ b/utility/synapse-utility-date/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-date</artifactId>

--- a/utility/synapse-utility-number/pom.xml
+++ b/utility/synapse-utility-number/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>utility</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>utility</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>synapse-utility-number</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/utility/synapse-utility-number/pom.xml
+++ b/utility/synapse-utility-number/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-number</artifactId>

--- a/utility/synapse-utility-telephone/pom.xml
+++ b/utility/synapse-utility-telephone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>${revision}</version>
+        <version>0.4.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-telephone</artifactId>

--- a/utility/synapse-utility-telephone/pom.xml
+++ b/utility/synapse-utility-telephone/pom.xml
@@ -1,13 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 American Express Travel Related Services Company, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>utility</artifactId>
-        <groupId>io.americanexpress.synapse</groupId>
-        <version>0.4.18-SNAPSHOT</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>io.americanexpress.synapse</groupId>
+        <artifactId>utility</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>synapse-utility-telephone</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Resolve all issues with Maven Central (Sonatype) Publishing due to [sunsetting of OSSRH](https://central.sonatype.org/pages/ossrh-eol/)