### PR TITLE
Add @Valid annotation

### DIFF
--- a/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadMonoImperativeRestController.java
+++ b/api/synapse-api-rest-imperative/src/main/java/io/americanexpress/synapse/api/rest/imperative/controller/BaseReadMonoImperativeRestController.java
@@ -7,6 +7,7 @@ import io.americanexpress.synapse.service.imperative.service.BaseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,7 +51,7 @@ public abstract class BaseReadMonoImperativeRestController<
             @ApiResponse(responseCode = "403", description = "Forbidden"),
     })
     @PostMapping(INQUIRY_RESULTS)
-    public ResponseEntity<O> read(@RequestHeader HttpHeaders headers, @RequestBody I serviceRequest) {
+    public ResponseEntity<O> read(@RequestHeader HttpHeaders headers, @RequestBody @Valid I serviceRequest) {
         logger.entry(serviceRequest);
 
         final O serviceResponse = service.execute(serviceRequest);


### PR DESCRIPTION
# synapse-api-rest-imperative

- Add @Valid annotation to the BaseReadMonoImperativeRestController class