### PR TITLE
Feature/webflux poa endpoints

### DIFF
--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadFluxReactiveController.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadFluxReactiveController.java
@@ -39,7 +39,7 @@ import reactor.core.publisher.Flux;
 public abstract class BaseReadFluxReactiveController<I extends BaseServiceRequest, O extends BaseServiceResponse, S extends BaseReadFluxReactiveService<I, O>> extends BaseController<S> {
 
     /**
-     * The constant MULTIPLE_RESULTS.
+     * The constant MULTIPLE RESULTS.
      */
     public static final String MULTIPLE_RESULTS = "/multiple-results";
 

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadFluxReactiveController.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadFluxReactiveController.java
@@ -41,7 +41,7 @@ public abstract class BaseReadFluxReactiveController<I extends BaseServiceReques
     /**
      * The constant MULTIPLE_RESULTS.
      */
-    public static final String MULTIPLE_RESULTS = "/multiple_results";
+    public static final String MULTIPLE_RESULTS = "/multiple-results";
 
     /**
      * Get a list of multiple resources from the back end service.

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadMonoReactiveController.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadMonoReactiveController.java
@@ -42,7 +42,7 @@ public abstract class BaseReadMonoReactiveController<I extends BaseServiceReques
     /**
      * The constant INQUIRY_RESULTS.
      */
-    public static final String INQUIRY_RESULTS = "/inquiry_results";
+    public static final String INQUIRY_RESULTS = "/inquiry-results";
 
     /**
      * Get a single resource from the back end service.

--- a/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadMonoReactiveController.java
+++ b/service/synapse-service-reactive-rest/src/main/java/io/americanexpress/synapse/service/reactive/rest/controller/BaseReadMonoReactiveController.java
@@ -40,7 +40,7 @@ import reactor.core.publisher.Mono;
 public abstract class BaseReadMonoReactiveController<I extends BaseServiceRequest, O extends BaseServiceResponse, S extends BaseReadMonoReactiveService<I, O>> extends BaseController<S> {
 
     /**
-     * The constant INQUIRY_RESULTS.
+     * The constant INQUIRY RESULTS.
      */
     public static final String INQUIRY_RESULTS = "/inquiry-results";
 


### PR DESCRIPTION
# synapse-service-reactive-rest

## Description

adding the support for poa endpoints

## What changed in this PR

- `inquiry_results` changed to `inquiry-results`
- `multiple_results` changed to `multiple-results`