### PR TITLE
Bump Springboot framework patch version to 3.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kotlin.version>2.1.21</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.5</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.6</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.0</spring-cloud-framework.version>
 
         <!--Springdoc-->


### PR DESCRIPTION
- Bump Springboot framework patch version to `3.5.6`

## Addresses

Spring Framework 6.2.11 Available Now

RELEASES | BRIAN CLOZEL | SEPTEMBER 11, 2025 | ... On behalf of the team and everyone who has contributed, I am pleased to announce that Spring Framework 6.2.11 is available now.

Spring Framework 6.2.11 ships with 23 fixes and documentation improvements. This version will be shipped next week with Spring Boot 3.4.10 and 3.5.6.

**CVE-2025-41249**

This release addresses CVE-2025-41249 for "Spring Framework Annotation Detection Vulnerability", which was published in conjunction with CVE-2025-41248 for "Spring Security authorization bypass for method security annotations on parameterized types". See Spring Security and Spring Framework Release Fixes for CVE-2025-41248 and CVE-2025-41249 for further details.

Open source support for the Spring Framework 5.3.x and 6.1.x generations has ended; however, the fix for CVE-2025-41249 has been applied to the Spring Framework 5.3.45 and 6.1.23 commercial releases, which are available now.

If you are not a commercial customer, please consider upgrading to a supported open source version of Spring Framework at your earliest convenience. Commercial customers using Spring Boot 2.7, 3.2, or 3.3 can make use of Spring Boot Hotfix releases 2.7.29.1, 3.2.18.1, and 3.3.15.1. Releases are available now on the Spring commercial artifact repository and can be accessed with a Spring Enterprise Subscription.