### PR TITLE
Patch spring framework to version 3.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kotlin.version>2.2.0</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.6</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.7</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.0</spring-cloud-framework.version>
 
         <!--Springdoc-->

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kotlin.version>2.2.0</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.7</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.9</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.0</spring-cloud-framework.version>
 
         <!--Springdoc-->

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <!--Spring Versions-->
         <spring-boot-framework.version>3.5.9</spring-boot-framework.version>
-        <spring-cloud-framework.version>2025.0.0</spring-cloud-framework.version>
+        <spring-cloud-framework.version>2025.0.1</spring-cloud-framework.version>
 
         <!--Springdoc-->
         <springdoc.version>2.8.9</springdoc.version>


### PR DESCRIPTION
Patch spring framework to version 3.5.9

3.5.9 is the last 3.x.x update. Next updates will need to be on 4.x.x

<img width="1142" height="459" alt="image" src="https://github.com/user-attachments/assets/5e68c932-482d-4d9c-8ce9-bc8b1ae9459c" />
