### PR TITLE
Add GitHub workflow to compare dependencies with customizable package…

### DIFF
--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -143,9 +143,6 @@ jobs:
                   summary_lines.append(f"- `{u}`")
               summary_lines.append(f"\n**Total minor upgrades:** {len(set(minor_upgrades))}\n")
           
-          # Note about patch upgrades being ignored
-          summary_lines.append("---\n")
-          summary_lines.append("ℹ️ **Note:** Patch-level upgrades (0.0.x) are excluded from this summary.")
           
           summary = "\n".join(summary_lines)
           
@@ -192,7 +189,6 @@ jobs:
           
           step_summary_lines.append("---\n")
           step_summary_lines.append("📦 **Full details available in the workflow artifact:** `dependency-comparison-summary`")
-          step_summary_lines.append("\nℹ️ **Note:** Patch-level upgrades (0.0.x) are excluded from this summary.")
           
           step_summary = "\n".join(step_summary_lines)
           

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -1,0 +1,194 @@
+name: Compare Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Maven package (e.g., org.springframework.boot:spring-boot-dependencies)'
+        required: true
+        default: 'org.springframework.boot:spring-boot-dependencies'
+        type: string
+      version:
+        description: 'Version to compare against (e.g., 3.5.9)'
+        required: true
+        default: '3.5.9'
+        type: string
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Run Maven versions:compare-dependencies
+        id: compare
+        run: |
+          mvn versions:compare-dependencies -DremotePom=${{ inputs.package }}:${{ inputs.version }} > compare-output.txt 2>&1 || true
+          cat compare-output.txt
+
+      - name: Parse and generate summary
+        id: summary
+        env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 << 'EOF'
+          import re
+          import os
+          
+          downgrades = set()
+          upgrades = []
+          notable_upgrades = []
+          
+          # Notable upgrade patterns (major version changes, security updates, etc.)
+          notable_patterns = [
+              r'spring-boot',
+              r'spring-framework',
+              r'spring-security',
+              r'hibernate',
+              r'junit',
+              r'mockito',
+              r'log4j',
+              r'jackson',
+              r'netty',
+              r'tomcat',
+              r'jetty',
+          ]
+          
+          def is_notable(dep_name):
+              dep_lower = dep_name.lower()
+              return any(pattern in dep_lower for pattern in notable_patterns)
+          
+          def compare_versions(old_ver, new_ver):
+              """Compare two version strings. Returns -1 if downgrade, 1 if upgrade, 0 if same."""
+              old_parts = re.findall(r'\d+', old_ver)
+              new_parts = re.findall(r'\d+', new_ver)
+              
+              if not old_parts or not new_parts:
+                  return 0
+              
+              for i in range(min(len(old_parts), len(new_parts))):
+                  old_num = int(old_parts[i])
+                  new_num = int(new_parts[i])
+                  if new_num < old_num:
+                      return -1
+                  elif new_num > old_num:
+                      return 1
+              
+              # If all compared parts are equal, check minor version
+              if len(old_parts) >= 2 and len(new_parts) >= 2:
+                  if int(new_parts[1]) < int(old_parts[1]):
+                      return -1
+                  elif int(new_parts[1]) > int(old_parts[1]):
+                      return 1
+              
+              return 0
+          
+          with open('compare-output.txt', 'r') as f:
+              for line in f:
+                  if '[INFO]   ' in line and ' -> ' in line:
+                      match = re.search(r'\[INFO\]\s+([^\s].*?)\s+\.+\s+([0-9.]+[^\s]*)\s+->\s+([0-9.]+[^\s]*)', line)
+                      if match:
+                          dep = match.group(1).strip()
+                          old_ver = match.group(2).strip()
+                          new_ver = match.group(3).strip()
+                          
+                          comparison = compare_versions(old_ver, new_ver)
+                          
+                          if comparison < 0:
+                              downgrades.add(f'{dep}: {old_ver} -> {new_ver}')
+                          elif comparison > 0:
+                              upgrade_entry = f'{dep}: {old_ver} -> {new_ver}'
+                              upgrades.append(upgrade_entry)
+                              if is_notable(dep):
+                                  notable_upgrades.append(upgrade_entry)
+          
+          # Generate summary
+          package = os.environ.get('PACKAGE', 'unknown')
+          version = os.environ.get('VERSION', 'unknown')
+          
+          summary_lines = []
+          summary_lines.append("# Dependency Comparison Summary")
+          summary_lines.append(f"\n**Comparing against:** `{package}:{version}`\n")
+          
+          if downgrades:
+              summary_lines.append("## ⚠️ DOWNGRADES (Most Important)")
+              summary_lines.append("")
+              for d in sorted(downgrades):
+                  summary_lines.append(f"- `{d}`")
+              summary_lines.append(f"\n**Total downgrades:** {len(downgrades)}\n")
+          else:
+              summary_lines.append("## ✅ No Downgrades Found\n")
+          
+          if notable_upgrades:
+              summary_lines.append("## 📈 Notable Upgrades")
+              summary_lines.append("")
+              for u in sorted(notable_upgrades):
+                  summary_lines.append(f"- `{u}`")
+              summary_lines.append(f"\n**Total notable upgrades:** {len(notable_upgrades)}\n")
+          
+          if upgrades:
+              summary_lines.append("## 📦 All Upgrades")
+              summary_lines.append(f"\n**Total upgrades:** {len(upgrades)}\n")
+              summary_lines.append("<details>")
+              summary_lines.append("<summary>Click to expand full upgrade list</summary>")
+              summary_lines.append("")
+              for u in sorted(upgrades):
+                  summary_lines.append(f"- `{u}`")
+              summary_lines.append("</details>")
+          
+          summary = "\n".join(summary_lines)
+          
+          # Write summary to file
+          with open('summary.md', 'w') as f:
+              f.write(summary)
+          
+          # Also print to console
+          print("\n" + "="*80)
+          print(summary)
+          print("="*80)
+          EOF
+
+      - name: Display summary
+        run: |
+          cat summary.md
+
+      - name: Add job summary
+        run: |
+          cat summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment on workflow (if PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const summary = fs.readFileSync('summary.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: summary
+            });
+
+      - name: Upload summary as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-comparison-summary
+          path: summary.md
+          retention-days: 30
+

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -54,52 +54,41 @@ jobs:
           import os
           
           downgrades = set()
-          upgrades = []
-          notable_upgrades = []
+          major_upgrades = []
+          minor_upgrades = []
           
-          # Notable upgrade patterns (major version changes, security updates, etc.)
-          notable_patterns = [
-              r'spring-boot',
-              r'spring-framework',
-              r'spring-security',
-              r'hibernate',
-              r'junit',
-              r'mockito',
-              r'log4j',
-              r'jackson',
-              r'netty',
-              r'tomcat',
-              r'jetty',
-          ]
-          
-          def is_notable(dep_name):
-              dep_lower = dep_name.lower()
-              return any(pattern in dep_lower for pattern in notable_patterns)
-          
-          def compare_versions(old_ver, new_ver):
-              """Compare two version strings. Returns -1 if downgrade, 1 if upgrade, 0 if same."""
+          def get_version_type(old_ver, new_ver):
+              """
+              Compare two version strings.
+              Returns: 'downgrade', 'major', 'minor', 'patch', or 'same'
+              """
               old_parts = re.findall(r'\d+', old_ver)
               new_parts = re.findall(r'\d+', new_ver)
               
               if not old_parts or not new_parts:
-                  return 0
+                  return 'same'
               
-              for i in range(min(len(old_parts), len(new_parts))):
-                  old_num = int(old_parts[i])
-                  new_num = int(new_parts[i])
-                  if new_num < old_num:
-                      return -1
-                  elif new_num > old_num:
-                      return 1
+              # Compare major version (first number)
+              old_major = int(old_parts[0])
+              new_major = int(new_parts[0])
               
-              # If all compared parts are equal, check minor version
+              if new_major < old_major:
+                  return 'downgrade'
+              elif new_major > old_major:
+                  return 'major'
+              
+              # Major versions are equal, check minor version
               if len(old_parts) >= 2 and len(new_parts) >= 2:
-                  if int(new_parts[1]) < int(old_parts[1]):
-                      return -1
-                  elif int(new_parts[1]) > int(old_parts[1]):
-                      return 1
+                  old_minor = int(old_parts[1])
+                  new_minor = int(new_parts[1])
+                  
+                  if new_minor < old_minor:
+                      return 'downgrade'
+                  elif new_minor > old_minor:
+                      return 'minor'
               
-              return 0
+              # Major and minor are equal - this is a patch upgrade (we ignore these)
+              return 'patch'
           
           with open('compare-output.txt', 'r') as f:
               for line in f:
@@ -110,15 +99,16 @@ jobs:
                           old_ver = match.group(2).strip()
                           new_ver = match.group(3).strip()
                           
-                          comparison = compare_versions(old_ver, new_ver)
+                          version_type = get_version_type(old_ver, new_ver)
+                          entry = f'{dep}: {old_ver} -> {new_ver}'
                           
-                          if comparison < 0:
-                              downgrades.add(f'{dep}: {old_ver} -> {new_ver}')
-                          elif comparison > 0:
-                              upgrade_entry = f'{dep}: {old_ver} -> {new_ver}'
-                              upgrades.append(upgrade_entry)
-                              if is_notable(dep):
-                                  notable_upgrades.append(upgrade_entry)
+                          if version_type == 'downgrade':
+                              downgrades.add(entry)
+                          elif version_type == 'major':
+                              major_upgrades.append(entry)
+                          elif version_type == 'minor':
+                              minor_upgrades.append(entry)
+                          # Ignore patch upgrades
           
           # Generate summary
           package = os.environ.get('PACKAGE', 'unknown')
@@ -137,22 +127,23 @@ jobs:
           else:
               summary_lines.append("## ✅ No Downgrades Found\n")
           
-          if notable_upgrades:
-              summary_lines.append("## 📈 Notable Upgrades")
+          if major_upgrades:
+              summary_lines.append("## 🔴 Major Upgrades (x.0.0)")
               summary_lines.append("")
-              for u in sorted(notable_upgrades):
+              for u in sorted(set(major_upgrades)):
                   summary_lines.append(f"- `{u}`")
-              summary_lines.append(f"\n**Total notable upgrades:** {len(notable_upgrades)}\n")
+              summary_lines.append(f"\n**Total major upgrades:** {len(set(major_upgrades))}\n")
           
-          if upgrades:
-              summary_lines.append("## 📦 All Upgrades")
-              summary_lines.append(f"\n**Total upgrades:** {len(upgrades)}\n")
-              summary_lines.append("<details>")
-              summary_lines.append("<summary>Click to expand full upgrade list</summary>")
+          if minor_upgrades:
+              summary_lines.append("## 🟡 Minor Upgrades (0.x.0)")
               summary_lines.append("")
-              for u in sorted(upgrades):
+              for u in sorted(set(minor_upgrades)):
                   summary_lines.append(f"- `{u}`")
-              summary_lines.append("</details>")
+              summary_lines.append(f"\n**Total minor upgrades:** {len(set(minor_upgrades))}\n")
+          
+          # Note about patch upgrades being ignored
+          summary_lines.append("---\n")
+          summary_lines.append("ℹ️ **Note:** Patch-level upgrades (0.0.x) are excluded from this summary.")
           
           summary = "\n".join(summary_lines)
           
@@ -161,7 +152,7 @@ jobs:
               f.write(summary)
           
           # Create truncated summary for step summary (GitHub limit: 1024k)
-          # Only include downgrades and limited notable upgrades
+          # Include downgrades and limited major/minor upgrades
           step_summary_lines = []
           step_summary_lines.append("# Dependency Comparison Summary")
           step_summary_lines.append(f"\n**Comparing against:** `{package}:{version}`\n")
@@ -175,19 +166,31 @@ jobs:
           else:
               step_summary_lines.append("## ✅ No Downgrades Found\n")
           
-          if notable_upgrades:
-              step_summary_lines.append("## 📈 Notable Upgrades (First 50)")
+          if major_upgrades:
+              unique_major = sorted(set(major_upgrades))
+              step_summary_lines.append("## 🔴 Major Upgrades (x.0.0)")
               step_summary_lines.append("")
-              unique_notable = sorted(set(notable_upgrades))[:50]
-              for u in unique_notable:
+              # Show first 50 major upgrades
+              for u in unique_major[:50]:
                   step_summary_lines.append(f"- `{u}`")
-              total_unique = len(set(notable_upgrades))
-              if total_unique > 50:
-                  step_summary_lines.append(f"\n... and {total_unique - 50} more notable upgrades")
-              step_summary_lines.append(f"\n**Total notable upgrades:** {total_unique}\n")
+              if len(unique_major) > 50:
+                  step_summary_lines.append(f"\n... and {len(unique_major) - 50} more major upgrades")
+              step_summary_lines.append(f"\n**Total major upgrades:** {len(unique_major)}\n")
+          
+          if minor_upgrades:
+              unique_minor = sorted(set(minor_upgrades))
+              step_summary_lines.append("## 🟡 Minor Upgrades (0.x.0)")
+              step_summary_lines.append("")
+              # Show first 50 minor upgrades
+              for u in unique_minor[:50]:
+                  step_summary_lines.append(f"- `{u}`")
+              if len(unique_minor) > 50:
+                  step_summary_lines.append(f"\n... and {len(unique_minor) - 50} more minor upgrades")
+              step_summary_lines.append(f"\n**Total minor upgrades:** {len(unique_minor)}\n")
           
           step_summary_lines.append("---\n")
           step_summary_lines.append("📦 **Full details available in the workflow artifact:** `dependency-comparison-summary`")
+          step_summary_lines.append("\nℹ️ **Note:** Patch-level upgrades (0.0.x) are excluded from this summary.")
           
           step_summary = "\n".join(step_summary_lines)
           

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -135,6 +135,8 @@ jobs:
               for u in sorted(set(major_upgrades)):
                   summary_lines.append(f"- `{u}`")
               summary_lines.append(f"\n**Total major upgrades:** {len(set(major_upgrades))}\n")
+          else:
+              summary_lines.append("## ✅ No Major Upgrades Found\n")
           
           if minor_upgrades:
               summary_lines.append("## 🟡 Minor Upgrades (0.x.0)")
@@ -175,6 +177,8 @@ jobs:
               if len(unique_major) > 50:
                   step_summary_lines.append(f"\n... and {len(unique_major) - 50} more major upgrades")
               step_summary_lines.append(f"\n**Total major upgrades:** {len(unique_major)}\n")
+          else:
+              step_summary_lines.append("## ✅ No Major Upgrades Found\n")
           
           if minor_upgrades:
               unique_minor = sorted(set(minor_upgrades))

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -13,6 +13,8 @@ on:
         required: true
         default: '3.5.9'
         type: string
+  push:
+    branches: [ feature/add-compare-dependencies-workflow ]
 
 jobs:
   compare:
@@ -40,14 +42,14 @@ jobs:
       - name: Run Maven versions:compare-dependencies
         id: compare
         run: |
-          mvn versions:compare-dependencies -DremotePom=${{ inputs.package }}:${{ inputs.version }} > compare-output.txt 2>&1 || true
+          mvn versions:compare-dependencies -DremotePom=${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}:${{ inputs.version || '3.5.9' }} > compare-output.txt 2>&1 || true
           cat compare-output.txt
 
       - name: Parse and generate summary
         id: summary
         env:
-          PACKAGE: ${{ inputs.package }}
-          VERSION: ${{ inputs.version }}
+          PACKAGE: ${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}
+          VERSION: ${{ inputs.version || '3.5.9' }}
         run: |
           python3 << 'EOF'
           import re

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -14,7 +14,8 @@ on:
         default: '3.5.9'
         type: string
   push:
-    branches: [ feature/add-compare-dependencies-workflow ]
+    branches:
+      - feature/add-compare-dependencies-workflow
 
 jobs:
   compare:

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -13,6 +13,8 @@ on:
         required: true
         default: '3.5.9'
         type: string
+  push:
+    branches: [ feature/add-compare-dependencies-workflow ]
 
 jobs:
   compare:

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -158,9 +158,44 @@ jobs:
           
           summary = "\n".join(summary_lines)
           
-          # Write summary to file
+          # Write full summary to file
           with open('summary.md', 'w') as f:
               f.write(summary)
+          
+          # Create truncated summary for step summary (GitHub limit: 1024k)
+          # Only include downgrades and limited notable upgrades
+          step_summary_lines = []
+          step_summary_lines.append("# Dependency Comparison Summary")
+          step_summary_lines.append(f"\n**Comparing against:** `{package}:{version}`\n")
+          
+          if downgrades:
+              step_summary_lines.append("## ⚠️ DOWNGRADES (Most Important)")
+              step_summary_lines.append("")
+              for d in sorted(downgrades):
+                  step_summary_lines.append(f"- `{d}`")
+              step_summary_lines.append(f"\n**Total downgrades:** {len(downgrades)}\n")
+          else:
+              step_summary_lines.append("## ✅ No Downgrades Found\n")
+          
+          if notable_upgrades:
+              step_summary_lines.append("## 📈 Notable Upgrades (First 50)")
+              step_summary_lines.append("")
+              unique_notable = sorted(set(notable_upgrades))[:50]
+              for u in unique_notable:
+                  step_summary_lines.append(f"- `{u}`")
+              total_unique = len(set(notable_upgrades))
+              if total_unique > 50:
+                  step_summary_lines.append(f"\n... and {total_unique - 50} more notable upgrades")
+              step_summary_lines.append(f"\n**Total notable upgrades:** {total_unique}\n")
+          
+          step_summary_lines.append("---\n")
+          step_summary_lines.append("📦 **Full details available in the workflow artifact:** `dependency-comparison-summary`")
+          
+          step_summary = "\n".join(step_summary_lines)
+          
+          # Write truncated summary for step summary
+          with open('step-summary.md', 'w') as f:
+              f.write(step_summary)
           
           # Also print to console
           print("\n" + "="*80)
@@ -174,7 +209,7 @@ jobs:
 
       - name: Add job summary
         run: |
-          cat summary.md >> $GITHUB_STEP_SUMMARY
+          cat step-summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on workflow (if PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -13,8 +13,6 @@ on:
         required: true
         default: '3.5.9'
         type: string
-  push:
-    branches: [ feature/add-compare-dependencies-workflow ]
 
 jobs:
   compare:
@@ -42,14 +40,14 @@ jobs:
       - name: Run Maven versions:compare-dependencies
         id: compare
         run: |
-          mvn versions:compare-dependencies -DremotePom=${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}:${{ inputs.version || '3.5.9' }} > compare-output.txt 2>&1 || true
+          mvn versions:compare-dependencies -DremotePom=${{ inputs.package }}:${{ inputs.version }} > compare-output.txt 2>&1 || true
           cat compare-output.txt
 
       - name: Parse and generate summary
         id: summary
         env:
-          PACKAGE: ${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}
-          VERSION: ${{ inputs.version || '3.5.9' }}
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
         run: |
           python3 << 'EOF'
           import re

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   compare:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Run Maven versions:compare-dependencies
         id: compare
         run: |
-          mvn versions:compare-dependencies -DremotePom=${{ inputs.package }}:${{ inputs.version }} > compare-output.txt 2>&1 || true
+          mvn versions:compare-dependencies -DremotePom=${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}:${{ inputs.version || '3.5.9' }} > compare-output.txt 2>&1 || true
           cat compare-output.txt
 
       - name: Parse and generate summary
         id: summary
         env:
-          PACKAGE: ${{ inputs.package }}
-          VERSION: ${{ inputs.version }}
+          PACKAGE: ${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}
+          VERSION: ${{ inputs.version || '3.5.9' }}
         run: |
           python3 << 'EOF'
           import re

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -13,9 +13,6 @@ on:
         required: true
         default: '3.5.9'
         type: string
-  push:
-    branches:
-      - feature/add-compare-dependencies-workflow
 
 jobs:
   compare:
@@ -43,14 +40,14 @@ jobs:
       - name: Run Maven versions:compare-dependencies
         id: compare
         run: |
-          mvn versions:compare-dependencies -DremotePom=${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}:${{ inputs.version || '3.5.9' }} > compare-output.txt 2>&1 || true
+          mvn versions:compare-dependencies -DremotePom=${{ inputs.package }}:${{ inputs.version }} > compare-output.txt 2>&1 || true
           cat compare-output.txt
 
       - name: Parse and generate summary
         id: summary
         env:
-          PACKAGE: ${{ inputs.package || 'org.springframework.boot:spring-boot-dependencies' }}
-          VERSION: ${{ inputs.version || '3.5.9' }}
+          PACKAGE: ${{ inputs.package }}
+          VERSION: ${{ inputs.version }}
         run: |
           python3 << 'EOF'
           import re

--- a/.github/workflows/compare-dependencies.yml
+++ b/.github/workflows/compare-dependencies.yml
@@ -144,7 +144,8 @@ jobs:
               for u in sorted(set(minor_upgrades)):
                   summary_lines.append(f"- `{u}`")
               summary_lines.append(f"\n**Total minor upgrades:** {len(set(minor_upgrades))}\n")
-          
+          else:
+              summary_lines.append("## ✅ No Minor Upgrades Found\n")
           
           summary = "\n".join(summary_lines)
           
@@ -190,6 +191,8 @@ jobs:
               if len(unique_minor) > 50:
                   step_summary_lines.append(f"\n... and {len(unique_minor) - 50} more minor upgrades")
               step_summary_lines.append(f"\n**Total minor upgrades:** {len(unique_minor)}\n")
+          else:
+              step_summary_lines.append("## ✅ No Minor Upgrades Found\n")
           
           step_summary_lines.append("---\n")
           step_summary_lines.append("📦 **Full details available in the workflow artifact:** `dependency-comparison-summary`")


### PR DESCRIPTION
… and version

- Add workflow_dispatch workflow that accepts package and version inputs
- Run Maven versions:compare-dependencies command
- Parse output to identify downgrades and upgrades
- Display downgrades first (most important)
- Show notable upgrades (Spring, Hibernate, Jackson, etc.)
- Generate markdown summary with collapsible full upgrade list
- Upload summary as artifact and display in job summary