### PR TITLE
Patch spring framework to version 3.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <!--Spring Versions-->
         <spring-boot-framework.version>3.5.10</spring-boot-framework.version>
-        <spring-cloud-framework.version>2025.1.1</spring-cloud-framework.version>
+        <spring-cloud-framework.version>2025.0.1</spring-cloud-framework.version>
 
         <!--Springdoc-->
         <springdoc.version>2.8.9</springdoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
         <!--Spring Versions-->
         <spring-boot-framework.version>3.5.10</spring-boot-framework.version>
-        <spring-cloud-framework.version>2025.0.1</spring-cloud-framework.version>
+        <spring-cloud-framework.version>2025.1.1</spring-cloud-framework.version>
 
         <!--Springdoc-->
         <springdoc.version>2.8.9</springdoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kotlin.version>2.2.0</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.9</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.10</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.1</spring-cloud-framework.version>
 
         <!--Springdoc-->


### PR DESCRIPTION
- Patch spring framework to version `3.5.10`
- Does not update Spring Cloud Framework. Refer to [spring cloud framework supported versions](https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions#supported-releases)