### PR TITLE
Patch: assertj-core to version 3.27.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,14 @@
                 <artifactId>testcontainers</artifactId>
                 <version>1.21.2</version>
             </dependency>
+            <!-- CVE-2026-24400 (High/8.2) - Fixed in 3.27.7, added 2026-02-10
+                 TODO: Remove this override when spring-boot-dependencies includes assertj-core >= 3.27.7
+                 Check: mvn dependency:tree | grep assertj-core -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.27.7</version>
+            </dependency>
             <!--./END Temporary For Vulnerability Fix-->
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
## Security Fix: CVE-2026-24400 - AssertJ Core Vulnerability

### Summary
Added dependency override to fix **CVE-2026-24400** (High severity, CVSS 8.2) in `org.assertj:assertj-core`.

### Changes
- Overridden `assertj-core` version from `3.27.6` → `3.27.7` in root `pom.xml`
- Added inline documentation with CVE details, date added, and removal instructions

### Why This Override Is Needed
- **Current situation**: Spring Boot 3.5.10 provides assertj-core 3.27.6 (vulnerable)
- **Fix version**: assertj-core 3.27.7
- **No released Spring Boot version** currently includes 3.27.7 yet

### When This Can Be Removed
This temporary override can be removed when Spring Boot is upgraded to a version that includes assertj-core >= 3.27.7.

**To check**: Run `mvn dependency:tree | grep assertj-core` after future Spring Boot upgrades. When the BOM provides 3.27.7+, remove the override from the "Temporary For Vulnerability Fix" section in `pom.xml`.

### Verification
The dependency override is located in:
- File: `pom.xml` (root)
- Section: `<dependencyManagement>` → "Temporary For Vulnerability Fix"
- Lines: 615-622

### References
- CVE: CVE-2026-24400
- Severity: High (CVSS 8.2)
- Fixed in: org.assertj:assertj-core 3.27.7