### PR TITLE
Patch: commons-configuration2 and commons-fileupload to fix CVE-2024-29131 and CVE-2025-48976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,22 @@
                 <artifactId>assertj-core</artifactId>
                 <version>3.27.7</version>
             </dependency>
+            <!-- CVE-2024-29131 (High/7.3) - Fixed in 2.10.1, added 2026-02-11
+                 TODO: Remove this override when spring-boot-dependencies includes commons-configuration2 >= 2.10.1
+                 Check: mvn dependency:tree | grep commons-configuration2 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <!-- CVE-2025-48976 (High/7.5) - Fixed in 1.6, added 2026-02-11
+                 TODO: Remove this override when spring-boot-dependencies includes commons-fileupload >= 1.6
+                 Check: mvn dependency:tree | grep commons-fileupload -->
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6</version>
+            </dependency>
             <!--./END Temporary For Vulnerability Fix-->
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
## Security Fixes: CVE-2024-29131 and CVE-2025-48976 - Apache Commons Vulnerabilities

### Summary

Added dependency overrides to fix two critical vulnerabilities:
- [CVE-2024-29131](https://nvd.nist.gov/vuln/detail/CVE-2024-29131) (High severity, CVSS 7.3) in `org.apache.commons:commons-configuration2`
- [CVE-2025-48976](https://nvd.nist.gov/vuln/detail/CVE-2025-48976) (High severity, CVSS 7.5) in `commons-fileupload:commons-fileupload`

### Changes

• Overridden `commons-configuration2` version to `2.10.1` in root `pom.xml`
• Overridden `commons-fileupload` version to `1.6` in root `pom.xml`
• Added inline documentation with CVE details, date added, and removal instructions for both dependencies

### Why These Overrides Are Needed

#### commons-configuration2
• Current situation: Spring Boot 3.5.10 provides commons-configuration2 < 2.10.1 (vulnerable)
• Fix version: commons-configuration2 2.10.1
• No released Spring Boot version currently includes 2.10.1 yet

#### commons-fileupload
• Current situation: Spring Boot 3.5.10 provides commons-fileupload < 1.6 (vulnerable)
• Fix version: commons-fileupload 1.6
• No released Spring Boot version currently includes 1.6 yet

### When These Can Be Removed

These temporary overrides can be removed when Spring Boot is upgraded to a version that includes:
- commons-configuration2 >= 2.10.1
- commons-fileupload >= 1.6

To check: Run `mvn dependency:tree | grep commons-configuration2` and `mvn dependency:tree | grep commons-fileupload` after future Spring Boot upgrades. When the BOM provides the patched versions, remove the overrides from the "Temporary For Vulnerability Fix" section in `pom.xml`.

### Verification

The dependency overrides are located in:

• File: `pom.xml` (root)
• Section: `<dependencyManagement>` → "Temporary For Vulnerability Fix"
• Lines: 623-638

### References

#### CVE-2024-29131
• CVE: [CVE-2024-29131](https://nvd.nist.gov/vuln/detail/CVE-2024-29131)
• Severity: High (CVSS 7.3)
• Fixed in: org.apache.commons:commons-configuration2 2.10.1

#### CVE-2025-48976
• CVE: [CVE-2025-48976](https://nvd.nist.gov/vuln/detail/CVE-2025-48976)
• Severity: High (CVSS 7.5)
• Fixed in: commons-fileupload:commons-fileupload 1.6
