### PR TITLE
Bump Spring Boot 3.5.15, Spring Cloud 2025.0.3, and Netty 4.1.135.Final for active CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <!--Spring Versions-->
         <spring-boot-framework.version>3.5.15</spring-boot-framework.version>
-        <spring-cloud-framework.version>2025.0.2</spring-cloud-framework.version>
+        <spring-cloud-framework.version>2025.0.3</spring-cloud-framework.version>
 
         <!--Springdoc-->
         <springdoc.version>2.8.17</springdoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -625,23 +625,6 @@
 
             <!--External Dependencies-->
             <!--Temporary For Vulnerability Fix-->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.135.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.55</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers</artifactId>
-                <version>1.21.2</version>
-            </dependency>
             <!-- CVE-2025-48924 (High/7.5) - Fixed in 3.18.0; pinned to 3.20.0, added 2025-07-11
                  TODO: Remove this override when spring-boot-dependencies includes commons-lang3 >= 3.18.0
                  Check: mvn dependency:tree | grep commons-lang3 -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <kotlin.version>2.3.20</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.14</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.15</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.2</spring-cloud-framework.version>
 
         <!--Springdoc-->
@@ -628,7 +628,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.134.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## What

| Property | From | To |
|---|---|---|
| `spring-boot-framework.version` | 3.5.14 | **3.5.15** |
| `spring-cloud-framework.version` | 2025.0.2 | **2025.0.3** |
| `netty` | 4.1.134.Final (override) | **4.1.135.Final** (now BOM-managed) |

Also removed three now-redundant temporary CVE overrides — see "Override cleanup" below.

## Why

Active CVEs flagged in downstream apps. The version bumps are minimal latest-patch bumps within their existing lines — no feature-line jumps.

- **Spring Boot 3.5.15** — latest 3.5.x maintenance release. Pulls Spring Framework 6.2.19, reactor-netty 1.2.18, Jackson 2.21.4, etc.
- **Spring Cloud 2025.0.3** — Spring Cloud `2025.0.x` (Northfields) is the release train paired with Spring Boot 3.5.x; `2025.0.3` is the latest patch in that train. Bumped alongside Boot to keep the managed BOMs aligned. (`2025.1.x` is for Boot 3.6 and is deliberately **not** used here.)
- **Netty 4.1.135.Final** — stays on the **4.1.x line** that Spring Boot 3.5.15 / reactor-netty 1.2.18 are tested against. Spring Boot 3.5.15's BOM now manages this exact version, so the explicit `netty-bom` override was dropped (see below). We deliberately did **not** jump to the 4.2.x feature line to avoid runtime/codec-layout risk. 4.1.135 retains the MadeYouReset fix (CVE-2025-55163, fixed at 4.1.124) plus subsequent patches.

## Override cleanup

Spring Boot 3.5.15's BOM has caught up to several of our temporary `dependencyManagement` overrides, so they were removed:

| Override | BOM-managed in 3.5.15 | Action |
|---|---|---|
| `io.netty:netty-bom` 4.1.135.Final | **4.1.135.Final** | Removed (redundant) |
| `tomcat-embed-core` 10.1.55 | **10.1.55** | Removed (redundant) |
| `testcontainers` 1.21.2 | **1.21.4** | Removed (pin was holding back the newer BOM patch) |

**Kept** (BOM still ships vulnerable or doesn't manage them):

| Override | CVE | Reason kept |
|---|---|---|
| `commons-lang3` 3.20.0 | CVE-2025-48924 | BOM still ships 3.17.0 (< 3.18.0 fix) |
| `commons-configuration2` 2.14.0 | CVE-2024-29131 | Not managed by the BOM |
| `commons-fileupload` 1.6.0 | CVE-2025-48976 | Not managed by the BOM |

## Verification

- `dependency:tree` resolves `io.netty:*` to `4.1.135.Final`, `tomcat-embed-core` to `10.1.55`, `testcontainers` to `1.21.4`, and `commons-lang3` to `3.20.0` after the override removal.
- Root `mvn validate` passes with the aligned Boot/Cloud train.
- Recommend the Testcontainers ITs run in CI to confirm runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
