### PR TITLE
Remove legacy Hibernate 5.x dependency management

### DIFF
--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -46,10 +46,6 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <!--Plugins-->

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -58,10 +58,6 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-ehcache</artifactId>
-        </dependency>
         <!-- persistence -->
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -789,23 +789,6 @@
                 <version>3.12.0</version>
             </dependency>
 
-            <!--Hibernate-->
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-ehcache</artifactId>
-                <version>5.6.15.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-annotations</artifactId>
-                <version>3.5.6-Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
-                <version>5.6.15.Final</version>
-            </dependency>
-
             <!--Jasypt-->
             <dependency>
                 <groupId>org.jasypt</groupId>


### PR DESCRIPTION
## What
Removes the legacy javax-based Hibernate 5.x artifacts from the root `dependencyManagement` and the two modules that consumed them.

Removed managed dependencies (root `pom.xml`):
- `org.hibernate:hibernate-ehcache` (5.6.15.Final)
- `org.hibernate:hibernate-annotations` (3.5.6-Final)
- `org.hibernate:hibernate-entitymanager` (5.6.15.Final)

Module usages pruned:
- `synapse-data-postgres` → `hibernate-ehcache`
- `synapse-data-db2` → `hibernate-entitymanager`
- `hibernate-annotations` was not referenced by any module.

## Why
These are leftovers from before the Jakarta / Hibernate 6 (`org.hibernate.orm:hibernate-core`) migration. No Java/XML/properties source references their packages, so they are dead dependency management that only risks pulling stale, javax-era, CVE-prone jars onto the classpath.

## Verification
`./mvnw clean install -pl data/synapse-data-db2,data/synapse-data-postgres -am -DskipTests` → **BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)