### PR TITLE
Dependency vulnerability sweep + Spring Boot 3.5.16: tomcat, netty, log4j BOM fix, jackson, postgresql, lz4, commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,42 @@
 
             <!--External Dependencies-->
             <!--Temporary For Vulnerability Fix-->
+            <!-- 20 CVEs across netty-codec-http/http2/stomp/haproxy/xml/redis/dns/compression and
+                 netty-handler-ssl-ocsp (memory exhaustion, CR/LF injection, zip bomb, OCSP cert
+                 validation) - Fixed in 4.1.136.Final, added 2026-07-27.
+                 Spring Boot 3.5.15/3.5.16 still manage netty 4.1.135.Final. Stay on the 4.1.x line
+                 that Boot/reactor-netty are tested against - do NOT move to 4.2.x here.
+                 TODO: Remove this override when spring-boot-dependencies includes netty >= 4.1.136.Final
+                 Check: mvn dependency:tree | grep io.netty -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.136.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- CVE-2026-55956 (Moderate) default servlet security constraints ignored method, plus
+                 CVE-2026-59084, CVE-2026-59083, CVE-2026-55955, CVE-2026-55276, CVE-2026-53434,
+                 CVE-2026-53404, CVE-2026-50229 (Low) - Fixed in 10.1.57, added 2026-07-27.
+                 Spring Boot 3.5.15/3.5.16 still manage tomcat 10.1.55. All three embed artifacts are
+                 pinned together so the Tomcat version stays internally consistent.
+                 TODO: Remove this override when spring-boot-dependencies includes tomcat >= 10.1.57
+                 Check: mvn dependency:tree | grep tomcat-embed -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>10.1.57</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>10.1.57</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.57</version>
+            </dependency>
             <!-- CVE-2025-48924 (High/7.5) - Fixed in 3.18.0; pinned to 3.20.0, added 2025-07-11
                  TODO: Remove this override when spring-boot-dependencies includes commons-lang3 >= 3.18.0
                  Check: mvn dependency:tree | grep commons-lang3 -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <junit.version>5.14.4</junit.version>
 
         <!--Logging-->
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
 
         <!--Db2-->
@@ -685,6 +685,50 @@
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.6.0</version>
             </dependency>
+            <!-- CVE-2026-59889, CVE-2026-54515, GHSA-mhm7-754m-9p8w (Moderate) - @JsonView and
+                 @JsonIgnoreProperties bypasses on deserialization - Fixed in 2.21.5, added 2026-07-27.
+                 Spring Boot 3.5.15/3.5.16 manage jackson-bom 2.21.4. Stays on the 2.21.x line.
+                 NOTE: this import must remain ABOVE the spring-boot-dependencies import or it is a no-op.
+                 TODO: Remove this override when spring-boot-dependencies includes jackson-bom >= 2.21.5
+                 Check: mvn dependency:tree | grep jackson-databind -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- CVE-2026-54291 (High) - silent channel-binding authentication downgrade - Fixed in
+                 42.7.12; pinned to 42.7.13, added 2026-07-27.
+                 Spring Boot 3.5.15/3.5.16 manage postgresql 42.7.11.
+                 TODO: Remove this override when spring-boot-dependencies includes postgresql >= 42.7.12
+                 Check: mvn dependency:tree | grep org.postgresql -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.13</version>
+            </dependency>
+            <!-- CVE-2026-59949 (Moderate) - native XXHash can crash the JVM on invalid byte array
+                 ranges - Fixed in 1.11.1, added 2026-07-27. Pulled in transitively by
+                 kafka-clients 3.9.2 via spring-kafka; Spring Boot manages kafka, not lz4.
+                 TODO: Remove this override when kafka-clients ships lz4-java >= 1.11.1
+                 Check: mvn dependency:tree | grep lz4 -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.11.1</version>
+            </dependency>
+            <!-- CVE-2024-26308, CVE-2024-25710 (Moderate) - Fixed in 1.26.0; pinned to 1.28.0,
+                 added 2026-07-27. Only the test-scoped path was vulnerable: testcontainers 1.21.4
+                 pulls 1.24.0 while spring-boot-loader-tools already pulls 1.27.1, so this pin also
+                 removes that version split.
+                 TODO: Remove this override when testcontainers ships commons-compress >= 1.26.0
+                 Check: mvn dependency:tree | grep commons-compress -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.28.0</version>
+            </dependency>
             <!--./END Temporary For Vulnerability Fix-->
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
@@ -697,6 +741,19 @@
                 <artifactId>lombok</artifactId>
                 <version>1.18.46</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <!--Logging BOM-->
+            <!-- MUST stay ABOVE the spring-boot-dependencies import below. Maven resolves
+                 dependencyManagement first-declaration-wins, so if spring-boot-dependencies is
+                 imported first its log4j2.version (2.24.3) silently wins and ${log4j.version} has
+                 no effect at all. Verify with: mvn dependency:tree | grep log4j-core -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!--Spring Dependencies-->
@@ -739,13 +796,6 @@
             </dependency>
 
             <!--Logging-->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.lmax</groupId>
                 <artifactId>disruptor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <kotlin.version>2.3.20</kotlin.version>
 
         <!--Spring Versions-->
-        <spring-boot-framework.version>3.5.15</spring-boot-framework.version>
+        <spring-boot-framework.version>3.5.16</spring-boot-framework.version>
         <spring-cloud-framework.version>2025.0.3</spring-cloud-framework.version>
 
         <!--Springdoc-->


### PR DESCRIPTION
Full-tree vulnerability sweep of the root `pom.xml`. Every resolved artifact/version pair in the reactor (374 of them, from `mvn dependency:tree` across all 107 modules and all scopes) was checked against the [OSV.dev](https://osv.dev) database. **9 vulnerable pairs were found; this PR fixes 7 of them**, taking the tree from 9 down to 3 affected pairs. Spring Boot is also moved to the newest patch.

## The notable one: the log4j BOM import was a no-op

`log4j-bom` was imported **below** `spring-boot-dependencies`. Maven resolves `dependencyManagement` **first-declaration-wins**, so Spring Boot's `log4j2.version` (2.24.3) silently won and the `${log4j.version}` property had *no effect at all* — the repo has been building against log4j **2.24.3** while the property claimed 2.25.4.

Moving the import above `spring-boot-dependencies` makes the property live again, and it is bumped 2.25.4 → **2.25.5**. A comment now records the ordering constraint so it doesn't regress. The same constraint applies to the new `jackson-bom` import.

This alone cleared 5 CVEs.

## Fixed

| Dependency | Was | Now | CVEs |
| --- | --- | --- | --- |
| `tomcat-embed-core` / `-el` / `-websocket` | 10.1.55 | **10.1.57** | CVE-2026-55956 (Moderate) + 7 Low |
| `io.netty:*` (via `netty-bom`) | 4.1.135.Final | **4.1.136.Final** | 20 CVEs in that release |
| `log4j-core`, `log4j-1.2-api` (via `log4j-bom`) | 2.24.3 *(effective)* | **2.25.5** | CVE-2026-34480, CVE-2026-34478, CVE-2026-34477, CVE-2025-68161, CVE-2026-34479 |
| `jackson-databind` (via `jackson-bom`) | 2.21.4 | **2.21.5** | CVE-2026-59889, CVE-2026-54515, GHSA-mhm7-754m-9p8w |
| `org.postgresql:postgresql` | 42.7.11 | **42.7.13** | CVE-2026-54291 (**High**) — silent channel-binding auth downgrade |
| `at.yawk.lz4:lz4-java` | 1.10.1 | **1.11.1** | CVE-2026-59949 — native XXHash JVM crash |
| `commons-compress` | 1.24.0 *(test scope)* | **1.28.0** | CVE-2024-26308, CVE-2024-25710 |

Notes:
- `lz4-java` arrives transitively from `kafka-clients` 3.9.2 via `spring-kafka`; Boot manages kafka but not lz4.
- `commons-compress` was only vulnerable on the **test-scoped** `testcontainers` 1.21.4 path — the compile path already pulled 1.27.1. The pin also removes that version split.
- All three `tomcat-embed` artifacts are pinned together so the Tomcat version stays internally consistent.
- Netty deliberately stays on the **4.1.x** line that Boot and reactor-netty are tested against, not 4.2.x.

## Spring Boot 3.5.15 → 3.5.16

Bumped as standing policy — staying on the newest patch means we aren't waiting on an upgrade when the next advisory lands. It does **not** fix any of the CVEs above; all of those still needed explicit overrides.

A full property diff of the two BOMs shows exactly three changes: `spring-amqp` 3.2.11 → 3.2.12, `spring-data-bom` 2025.0.12 → 2025.0.13, `spring-integration` 6.5.9 → 6.5.10. Everything else is identical, **including `spring-framework` (6.2.19 in both)**.

- **Spring Cloud stays at 2025.0.3** — already the newest patch in the 2025.0.x train that pairs with Boot 3.5.x. Crossing to 2025.1.x would mean a different Boot line.
- **Spring Framework / `spring-core` is not a separate knob here** — the four modules that declare `spring-core` do so without a version, so it moves with the Boot BOM automatically. Confirmed resolving to 6.2.19.
- No override became redundant: 3.5.16 still manages log4j2 2.24.3, jackson 2.21.4, postgresql 42.7.11, tomcat 10.1.55, netty 4.1.135.Final and commons-lang3 3.17.0.

## Covered by #484 — legacy Hibernate

The scan flagged **`hibernate-core` 5.6.15.Final — CVE-2026-0603 (High, second-order SQL injection)**, dragged in by the Hibernate 5-only `hibernate-ehcache` and `hibernate-entitymanager` pins consumed by `synapse-data-db2` and `synapse-data-postgres`. The 5.6 line is EOL so there is no patched version to pin to.

This is already handled by #484, which removes those artifacts (plus the unreferenced `hibernate-annotations` 3.5.6-Final) from `dependencyManagement` and from both modules — so it is deliberately left out of this PR. The two branches were test-merged and **apply cleanly with no conflicts**; the changes touch different regions of the root `pom.xml`. Merging #484 takes this sweep's remaining count from 3 down to 2.

## Not fixed — needs a migration, not a pin

**`querydsl-jpa` / `querydsl-apt` 5.1.0 — CVE-2024-49203 (High, HQL injection via `orderBy`).** `com.querydsl` is abandoned upstream at 5.1.0 with no fixed release; the maintained fork is `io.github.openfeign.querydsl` (currently 7.5), which has a different groupId and APT setup. Scope is limited to the `sample-data-postgres-book` sample module. Worth tracking separately.

## Override audit

Per the practice of pruning temporary pins as the BOM catches up, the pre-existing overrides were re-checked. All three are still required and were left in place:

- `commons-lang3` — BOM manages 3.17.0, below the 3.18.0 fix
- `commons-configuration2` — not managed by the BOM
- `commons-fileupload` — not managed by the BOM

Every new override carries a comment with its CVE, the fix version, the date added, and a `TODO` + `Check:` line so it can be removed once upstream catches up. The standing goal is for the "Temporary For Vulnerability Fix" block to be **empty**.

## Verification

- OSV re-scan of the post-change tree: **9 vulnerable pairs → 3** (querydsl counted twice for `-jpa` and `-apt`, plus the Hibernate finding that #484 removes); unchanged by the Boot bump
- `mvn dependency:tree` — confirmed every override is actually effective, including log4j now genuinely resolving to 2.25.5
- `mvn clean install -DskipITs` — full reactor **BUILD SUCCESS**, **1700 tests**, zero failures or errors, on 3.5.16
- `git merge-tree` against #484's branch — no conflicts