### PR TITLE
Release/v0.4.28

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-api-rest-imperative</artifactId>

--- a/api/synapse-api-rest-imperative/pom.xml
+++ b/api/synapse-api-rest-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-api-rest-imperative</artifactId>

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-api-rest-reactive</artifactId>

--- a/api/synapse-api-rest-reactive/pom.xml
+++ b/api/synapse-api-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>api</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-api-rest-reactive</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>archetype</artifactId>

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>archetype</artifactId>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-graphql</artifactId>

--- a/archetype/synapse-archetype-client-graphql/pom.xml
+++ b/archetype/synapse-archetype-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-graphql</artifactId>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-delete</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive-put</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>

--- a/archetype/synapse-archetype-client-rest-reactive/pom.xml
+++ b/archetype/synapse-archetype-client-rest-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest-reactive</artifactId>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest</artifactId>

--- a/archetype/synapse-archetype-client-rest/pom.xml
+++ b/archetype/synapse-archetype-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-client-rest</artifactId>

--- a/archetype/synapse-archetype-data-postgres/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-data-postgres</artifactId>

--- a/archetype/synapse-archetype-data-postgres/pom.xml
+++ b/archetype/synapse-archetype-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-data-postgres</artifactId>

--- a/archetype/synapse-archetype-service-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-delete</artifactId>

--- a/archetype/synapse-archetype-service-rest-delete/pom.xml
+++ b/archetype/synapse-archetype-service-rest-delete/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-delete</artifactId>

--- a/archetype/synapse-archetype-service-rest-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-put</artifactId>

--- a/archetype/synapse-archetype-service-rest-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-put</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-get/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-get</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-post/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-post</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-put</artifactId>

--- a/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
+++ b/archetype/synapse-archetype-service-rest-reactive-put/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>archetype</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-archetype-service-rest-reactive-put</artifactId>

--- a/client/client-samples/pom.xml
+++ b/client/client-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>client-samples</artifactId>

--- a/client/client-samples/pom.xml
+++ b/client/client-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>client-samples</artifactId>

--- a/client/client-samples/sample-client-graphql-book/pom.xml
+++ b/client/client-samples/sample-client-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-client-graphql-book</artifactId>

--- a/client/client-samples/sample-client-graphql-book/pom.xml
+++ b/client/client-samples/sample-client-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-graphql-book</artifactId>

--- a/client/client-samples/sample-client-reactive-football/pom.xml
+++ b/client/client-samples/sample-client-reactive-football/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-client-reactive-football</artifactId>

--- a/client/client-samples/sample-client-reactive-football/pom.xml
+++ b/client/client-samples/sample-client-reactive-football/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-reactive-football</artifactId>

--- a/client/client-samples/sample-client-reactive-weather/pom.xml
+++ b/client/client-samples/sample-client-reactive-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-client-reactive-weather</artifactId>

--- a/client/client-samples/sample-client-reactive-weather/pom.xml
+++ b/client/client-samples/sample-client-reactive-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-reactive-weather</artifactId>

--- a/client/client-samples/sample-client-weather/pom.xml
+++ b/client/client-samples/sample-client-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-client-weather</artifactId>

--- a/client/client-samples/sample-client-weather/pom.xml
+++ b/client/client-samples/sample-client-weather/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-client-weather</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>client</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>client</artifactId>

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-graphql</artifactId>

--- a/client/synapse-client-graphql/pom.xml
+++ b/client/synapse-client-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-client-graphql</artifactId>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-client-rest</artifactId>

--- a/client/synapse-client-rest/pom.xml
+++ b/client/synapse-client-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-rest</artifactId>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-soap</artifactId>

--- a/client/synapse-client-soap/pom.xml
+++ b/client/synapse-client-soap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-client-soap</artifactId>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-client-test</artifactId>

--- a/client/synapse-client-test/pom.xml
+++ b/client/synapse-client-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>client</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-client-test</artifactId>

--- a/data/data-samples/pom.xml
+++ b/data/data-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-samples</artifactId>

--- a/data/data-samples/pom.xml
+++ b/data/data-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>data-samples</artifactId>

--- a/data/data-samples/sample-data-cassandra-book/pom.xml
+++ b/data/data-samples/sample-data-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-cassandra-book</artifactId>

--- a/data/data-samples/sample-data-cassandra-book/pom.xml
+++ b/data/data-samples/sample-data-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-cassandra-book</artifactId>

--- a/data/data-samples/sample-data-cassandra-reactive/pom.xml
+++ b/data/data-samples/sample-data-cassandra-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-cassandra-reactive</artifactId>

--- a/data/data-samples/sample-data-cassandra-reactive/pom.xml
+++ b/data/data-samples/sample-data-cassandra-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-cassandra-reactive</artifactId>

--- a/data/data-samples/sample-data-db2-book/pom.xml
+++ b/data/data-samples/sample-data-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-db2-book</artifactId>

--- a/data/data-samples/sample-data-db2-book/pom.xml
+++ b/data/data-samples/sample-data-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-db2-book</artifactId>

--- a/data/data-samples/sample-data-mongodb-book/pom.xml
+++ b/data/data-samples/sample-data-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-mongodb-book</artifactId>

--- a/data/data-samples/sample-data-mongodb-book/pom.xml
+++ b/data/data-samples/sample-data-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mongodb-book</artifactId>

--- a/data/data-samples/sample-data-mongodb-reactive/pom.xml
+++ b/data/data-samples/sample-data-mongodb-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-mongodb-reactive</artifactId>

--- a/data/data-samples/sample-data-mongodb-reactive/pom.xml
+++ b/data/data-samples/sample-data-mongodb-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mongodb-reactive</artifactId>

--- a/data/data-samples/sample-data-mssql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mssql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-mssql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mssql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mssql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mssql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mysql-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mysql-book</artifactId>

--- a/data/data-samples/sample-data-mysql-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-mysql-book</artifactId>

--- a/data/data-samples/sample-data-mysql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-mysql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-mysql-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-mysql-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-mysql-reactive-book</artifactId>

--- a/data/data-samples/sample-data-oracle-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-book</artifactId>

--- a/data/data-samples/sample-data-oracle-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-oracle-book</artifactId>

--- a/data/data-samples/sample-data-oracle-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-book</artifactId>

--- a/data/data-samples/sample-data-oracle-reactive-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-book</artifactId>

--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-cp-book</artifactId>

--- a/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
+++ b/data/data-samples/sample-data-oracle-reactive-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-oracle-reactive-cp-book</artifactId>

--- a/data/data-samples/sample-data-postgres-book/pom.xml
+++ b/data/data-samples/sample-data-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-postgres-book</artifactId>

--- a/data/data-samples/sample-data-postgres-book/pom.xml
+++ b/data/data-samples/sample-data-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-postgres-book</artifactId>

--- a/data/data-samples/sample-data-redis-book/pom.xml
+++ b/data/data-samples/sample-data-redis-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-data-redis-book</artifactId>

--- a/data/data-samples/sample-data-redis-book/pom.xml
+++ b/data/data-samples/sample-data-redis-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-data-redis-book</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/data/synapse-data-cassandra/pom.xml
+++ b/data/synapse-data-cassandra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-cassandra</artifactId>

--- a/data/synapse-data-cassandra/pom.xml
+++ b/data/synapse-data-cassandra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-cassandra</artifactId>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-couchbase</artifactId>

--- a/data/synapse-data-couchbase/pom.xml
+++ b/data/synapse-data-couchbase/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-couchbase</artifactId>

--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-db2</artifactId>

--- a/data/synapse-data-db2/pom.xml
+++ b/data/synapse-data-db2/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-db2</artifactId>

--- a/data/synapse-data-jdbc/pom.xml
+++ b/data/synapse-data-jdbc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-jdbc</artifactId>

--- a/data/synapse-data-jdbc/pom.xml
+++ b/data/synapse-data-jdbc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-jdbc</artifactId>

--- a/data/synapse-data-jpa/pom.xml
+++ b/data/synapse-data-jpa/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-jpa</artifactId>

--- a/data/synapse-data-jpa/pom.xml
+++ b/data/synapse-data-jpa/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-jpa</artifactId>

--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-mongodb</artifactId>

--- a/data/synapse-data-mongodb/pom.xml
+++ b/data/synapse-data-mongodb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mongodb</artifactId>

--- a/data/synapse-data-mssql/pom.xml
+++ b/data/synapse-data-mssql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-mssql</artifactId>

--- a/data/synapse-data-mssql/pom.xml
+++ b/data/synapse-data-mssql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mssql</artifactId>

--- a/data/synapse-data-mysql/pom.xml
+++ b/data/synapse-data-mysql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-mysql</artifactId>

--- a/data/synapse-data-mysql/pom.xml
+++ b/data/synapse-data-mysql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-mysql</artifactId>

--- a/data/synapse-data-oracle/pom.xml
+++ b/data/synapse-data-oracle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-oracle</artifactId>

--- a/data/synapse-data-oracle/pom.xml
+++ b/data/synapse-data-oracle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-oracle</artifactId>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-postgres</artifactId>

--- a/data/synapse-data-postgres/pom.xml
+++ b/data/synapse-data-postgres/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-postgres</artifactId>

--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-data-redis</artifactId>

--- a/data/synapse-data-redis/pom.xml
+++ b/data/synapse-data-redis/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>data</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-data-redis</artifactId>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework</artifactId>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>framework</artifactId>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-api-docs</artifactId>

--- a/framework/synapse-framework-api-docs/pom.xml
+++ b/framework/synapse-framework-api-docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-framework-api-docs</artifactId>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-exception</artifactId>

--- a/framework/synapse-framework-exception/pom.xml
+++ b/framework/synapse-framework-exception/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-framework-exception</artifactId>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-framework-logging</artifactId>

--- a/framework/synapse-framework-logging/pom.xml
+++ b/framework/synapse-framework-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-logging</artifactId>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-framework-test</artifactId>

--- a/framework/synapse-framework-test/pom.xml
+++ b/framework/synapse-framework-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>framework</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-framework-test</artifactId>

--- a/function/function-samples/pom.xml
+++ b/function/function-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>function-samples</artifactId>

--- a/function/function-samples/pom.xml
+++ b/function/function-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>function-samples</artifactId>

--- a/function/function-samples/sample-function-book-aws/pom.xml
+++ b/function/function-samples/sample-function-book-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-function-book-aws</artifactId>

--- a/function/function-samples/sample-function-book-aws/pom.xml
+++ b/function/function-samples/sample-function-book-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-book-aws</artifactId>

--- a/function/function-samples/sample-function-greeter-aws/pom.xml
+++ b/function/function-samples/sample-function-greeter-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-function-greeter-aws</artifactId>

--- a/function/function-samples/sample-function-greeter-aws/pom.xml
+++ b/function/function-samples/sample-function-greeter-aws/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeter-aws</artifactId>

--- a/function/function-samples/sample-function-greeter-gcp/pom.xml
+++ b/function/function-samples/sample-function-greeter-gcp/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-function-greeter-gcp</artifactId>

--- a/function/function-samples/sample-function-greeter-gcp/pom.xml
+++ b/function/function-samples/sample-function-greeter-gcp/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeter-gcp</artifactId>

--- a/function/function-samples/sample-function-greeting/pom.xml
+++ b/function/function-samples/sample-function-greeting/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-greeting</artifactId>

--- a/function/function-samples/sample-function-greeting/pom.xml
+++ b/function/function-samples/sample-function-greeting/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-function-greeting</artifactId>

--- a/function/function-samples/sample-function-rest-book/pom.xml
+++ b/function/function-samples/sample-function-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-function-rest-book</artifactId>

--- a/function/function-samples/sample-function-rest-book/pom.xml
+++ b/function/function-samples/sample-function-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-function-rest-book</artifactId>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>function</artifactId>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>function</artifactId>

--- a/function/synapse-function/pom.xml
+++ b/function/synapse-function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-function</artifactId>

--- a/function/synapse-function/pom.xml
+++ b/function/synapse-function/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>function</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-function</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>synapse</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
-    <version>0.4.28-SNAPSHOT</version>
+    <version>0.4.28</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise
@@ -37,7 +37,7 @@
         <url>https://github.com/americanexpress/synapse</url>
         <connection>scm:git:https://github.com/americanexpress/synapse.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/americanexpress/synapse.git</developerConnection>
-        <tag>synapse-0.4.18</tag>
+        <tag>synapse-0.4.28</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>synapse</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>pom</packaging>
-    <version>0.4.28</version>
+    <version>0.4.29-SNAPSHOT</version>
 
     <description>
         Synapse is a set of lightweight foundational framework modules for rapid development built-in with enterprise
@@ -37,7 +37,7 @@
         <url>https://github.com/americanexpress/synapse</url>
         <connection>scm:git:https://github.com/americanexpress/synapse.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/americanexpress/synapse.git</developerConnection>
-        <tag>synapse-0.4.28</tag>
+        <tag>synapse-0.4.18</tag>
     </scm>
 
     <issueManagement>

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>publisher</artifactId>

--- a/publisher/pom.xml
+++ b/publisher/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>publisher</artifactId>

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-publisher-kafka</artifactId>

--- a/publisher/synapse-publisher-kafka/pom.xml
+++ b/publisher/synapse-publisher-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>publisher</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-publisher-kafka</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>service</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>service</artifactId>

--- a/service/service-samples/pom.xml
+++ b/service/service-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>service-samples</artifactId>

--- a/service/service-samples/pom.xml
+++ b/service/service-samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>service-samples</artifactId>

--- a/service/service-samples/sample-service-db2-book/pom.xml
+++ b/service/service-samples/sample-service-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-db2-book</artifactId>

--- a/service/service-samples/sample-service-db2-book/pom.xml
+++ b/service/service-samples/sample-service-db2-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-db2-book</artifactId>

--- a/service/service-samples/sample-service-graphql-book/pom.xml
+++ b/service/service-samples/sample-service-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-graphql-book</artifactId>

--- a/service/service-samples/sample-service-graphql-book/pom.xml
+++ b/service/service-samples/sample-service-graphql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-graphql-book</artifactId>

--- a/service/service-samples/sample-service-imperative-book/pom.xml
+++ b/service/service-samples/sample-service-imperative-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-imperative-book</artifactId>

--- a/service/service-samples/sample-service-imperative-book/pom.xml
+++ b/service/service-samples/sample-service-imperative-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-imperative-book</artifactId>

--- a/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-mongodb-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mongodb-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mongodb-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mssql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mssql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-mssql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mssql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mssql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mssql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-mysql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-mysql-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-cp-book</artifactId>

--- a/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-oracle-cp-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-oracle-cp-book</artifactId>

--- a/service/service-samples/sample-service-reactive-rest-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-rest-book</artifactId>

--- a/service/service-samples/sample-service-reactive-rest-book/pom.xml
+++ b/service/service-samples/sample-service-reactive-rest-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-rest-book</artifactId>

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-reactive-weather-client</artifactId>

--- a/service/service-samples/sample-service-reactive-weather-client/pom.xml
+++ b/service/service-samples/sample-service-reactive-weather-client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-reactive-weather-client</artifactId>

--- a/service/service-samples/sample-service-rest-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-rest-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-rest-cassandra-book/pom.xml
+++ b/service/service-samples/sample-service-rest-cassandra-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-rest-cassandra-book</artifactId>

--- a/service/service-samples/sample-service-rest-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-rest-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-rest-mysql-book</artifactId>

--- a/service/service-samples/sample-service-rest-mysql-book/pom.xml
+++ b/service/service-samples/sample-service-rest-mysql-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-mysql-book</artifactId>

--- a/service/service-samples/sample-service-rest-native-book/pom.xml
+++ b/service/service-samples/sample-service-rest-native-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-native-book</artifactId>

--- a/service/service-samples/sample-service-rest-native-book/pom.xml
+++ b/service/service-samples/sample-service-rest-native-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-rest-native-book</artifactId>

--- a/service/service-samples/sample-service-rest-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-rest-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-rest-oracle-book</artifactId>

--- a/service/service-samples/sample-service-rest-oracle-book/pom.xml
+++ b/service/service-samples/sample-service-rest-oracle-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-oracle-book</artifactId>

--- a/service/service-samples/sample-service-rest-postgres-book/pom.xml
+++ b/service/service-samples/sample-service-rest-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>sample-service-rest-postgres-book</artifactId>

--- a/service/service-samples/sample-service-rest-postgres-book/pom.xml
+++ b/service/service-samples/sample-service-rest-postgres-book/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service-samples</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>sample-service-rest-postgres-book</artifactId>

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-graphql</artifactId>

--- a/service/synapse-service-graphql/pom.xml
+++ b/service/synapse-service-graphql/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-graphql</artifactId>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-imperative</artifactId>

--- a/service/synapse-service-imperative/pom.xml
+++ b/service/synapse-service-imperative/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-imperative</artifactId>

--- a/service/synapse-service-reactive-rest/pom.xml
+++ b/service/synapse-service-reactive-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-reactive-rest</artifactId>

--- a/service/synapse-service-reactive-rest/pom.xml
+++ b/service/synapse-service-reactive-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-reactive-rest</artifactId>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-reactive</artifactId>

--- a/service/synapse-service-reactive/pom.xml
+++ b/service/synapse-service-reactive/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-reactive</artifactId>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-rest</artifactId>

--- a/service/synapse-service-rest/pom.xml
+++ b/service/synapse-service-rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-rest</artifactId>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-service-test</artifactId>

--- a/service/synapse-service-test/pom.xml
+++ b/service/synapse-service-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>service</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-service-test</artifactId>

--- a/subscriber/pom.xml
+++ b/subscriber/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>subscriber</artifactId>

--- a/subscriber/pom.xml
+++ b/subscriber/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>subscriber</artifactId>

--- a/subscriber/synapse-subscriber-kafka/pom.xml
+++ b/subscriber/synapse-subscriber-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>subscriber</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-subscriber-kafka</artifactId>

--- a/subscriber/synapse-subscriber-kafka/pom.xml
+++ b/subscriber/synapse-subscriber-kafka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>subscriber</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-subscriber-kafka</artifactId>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>utility</artifactId>

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>synapse</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>utility</artifactId>

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-utilities-common</artifactId>

--- a/utility/synapse-utilities-common/pom.xml
+++ b/utility/synapse-utilities-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utilities-common</artifactId>

--- a/utility/synapse-utility-cryptography/pom.xml
+++ b/utility/synapse-utility-cryptography/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-utility-cryptography</artifactId>

--- a/utility/synapse-utility-cryptography/pom.xml
+++ b/utility/synapse-utility-cryptography/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-cryptography</artifactId>

--- a/utility/synapse-utility-date/pom.xml
+++ b/utility/synapse-utility-date/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-date</artifactId>

--- a/utility/synapse-utility-date/pom.xml
+++ b/utility/synapse-utility-date/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-utility-date</artifactId>

--- a/utility/synapse-utility-number/pom.xml
+++ b/utility/synapse-utility-number/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-utility-number</artifactId>

--- a/utility/synapse-utility-number/pom.xml
+++ b/utility/synapse-utility-number/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-number</artifactId>

--- a/utility/synapse-utility-telephone/pom.xml
+++ b/utility/synapse-utility-telephone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28</version>
+        <version>0.4.29-SNAPSHOT</version>
     </parent>
 
     <artifactId>synapse-utility-telephone</artifactId>

--- a/utility/synapse-utility-telephone/pom.xml
+++ b/utility/synapse-utility-telephone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.americanexpress.synapse</groupId>
         <artifactId>utility</artifactId>
-        <version>0.4.28-SNAPSHOT</version>
+        <version>0.4.28</version>
     </parent>
 
     <artifactId>synapse-utility-telephone</artifactId>


### PR DESCRIPTION
Brings the CI-generated `next development iteration` version bump back onto `develop` after the 0.4.28 release.

## What

CI-authored change only — no hand edits. All **107** poms move `0.4.28-SNAPSHOT` → `0.4.29-SNAPSHOT`. The diff contains nothing but those version elements.

Commits are the two `[skip ci]` ones written by `release:prepare`:
- `a65ecaca` — `[skip ci] prepare release synapse-0.4.28`
- `67939e46` — `[skip ci] prepare for next development iteration`

## Release status: live on Maven Central

`snapshot-release-maven-central-deploy-job` completed and published. Verified directly against `repo1.maven.org` (the search.maven.org / central.sonatype.com UI indexes separately and is currently ~11 releases behind, so it is not a reliable check):

- Tag `synapse-0.4.28` created
- Jars + `.asc` GPG signatures present for every module spot-checked — `synapse-api-rest-imperative`, `synapse-api-rest-reactive`, `synapse-service-rest`, `synapse-framework-logging`, `synapse-data-postgres`, `synapse-client-rest`
- `maven-metadata.xml` lists `0.4.28`

```
curl -sI https://repo1.maven.org/maven2/io/americanexpress/synapse/synapse-api-rest-imperative/0.4.28/synapse-api-rest-imperative-0.4.28.jar
```

## What shipped in 0.4.28

The release was cut from `develop` after #485 and #484 merged, so it carries the full dependency vulnerability sweep:

- tomcat-embed 10.1.55 → **10.1.57**, netty 4.1.135 → **4.1.136.Final**
- **log4j BOM import-order fix** — the `log4j-bom` import sat below `spring-boot-dependencies`, so Boot's 2.24.3 silently won and `${log4j.version}` had no effect; now genuinely on **2.25.5**
- jackson 2.21.4 → **2.21.5**, postgresql 42.7.11 → **42.7.13** (High), lz4-java, commons-compress
- Spring Boot 3.5.15 → **3.5.16**
- Legacy Hibernate 5.x dependency management removed (#484)

The merged state was built before cutting: full reactor **BUILD SUCCESS**, **1700 tests** green.