### PR TITLE
Fix split Couchbase SDK by moving couchbase-client-bom above Boot's import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -756,6 +756,24 @@
                 <scope>import</scope>
             </dependency>
 
+            <!--Couchbase SDK BOM-->
+            <!-- MUST stay ABOVE the spring-boot-dependencies import below. Maven resolves
+                 dependencyManagement first-declaration-wins. Spring Boot manages
+                 com.couchbase.client:java-client (couchbase-client.version, 3.8.3 as of Boot
+                 3.5.16) but does NOT manage core-io. So with this BOM imported after Boot's,
+                 Boot won for java-client while this BOM won for core-io, splitting the SDK
+                 across java-client 3.8.3 + core-io 3.11.2. The whole com.couchbase.client
+                 family must move as ONE set - that is what this BOM is for (every artifact in
+                 it shares ${revision}).
+                 Verify with: mvn dependency:tree | grep com.couchbase.client -->
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>couchbase-client-bom</artifactId>
+                <version>3.11.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!--Spring Dependencies-->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -932,14 +950,6 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <!--Couchbase-->
-            <dependency>
-                <groupId>com.couchbase.client</groupId>
-                <artifactId>couchbase-client-bom</artifactId>
-                <version>3.11.2</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <!--Springdoc-->
             <dependency>


### PR DESCRIPTION
## The bug

synapse resolves **`java-client` 3.8.3 together with `core-io` 3.11.2** — a mismatched pair from the same SDK.

```
com.couchbase.client:core-io:jar:3.11.2
com.couchbase.client:java-client:jar:3.8.3      <-- wrong
```

`java-client` 3.8.3 is compiled against `core-io` 3.8.x. Running it against 3.11.2 risks `NoSuchMethodError` / `NoClassDefFoundError` at runtime.

## Cause

The `dependencyManagement` **first-declaration-wins** rule again. The `couchbase-client-bom` import sat *below* the `spring-boot-dependencies` import:

- Spring Boot manages `com.couchbase.client:java-client` via its `couchbase-client.version` property — **3.8.3** as of Boot 3.5.16 — so **Boot won for `java-client`**.
- Boot does **not** manage `core-io` (it's a transitive of `java-client`), so **`couchbase-client-bom` won for `core-io`**.

Net effect: the SDK got split across two versions. The BOM exists precisely to prevent that — every artifact in it shares `${revision}` — and it was only half applying.

This is the same class of silent misconfiguration as the `log4j-bom` ordering bug fixed in #485: the pom asserts one version, the build resolves another, and nothing errors.

## The fix

Move the import above `spring-boot-dependencies`, which puts the whole `com.couchbase.client` family on **3.11.2** — the version the BOM already declared, and the version consuming apps are independently forcing in their own remediation lists.

```
com.couchbase.client:core-io:jar:3.11.2
com.couchbase.client:java-client:jar:3.11.2     <-- aligned
```

A comment now records the ordering constraint, matching the ones added for `log4j-bom` and `jackson-bom` in #485.

## Verification

- **Before/after diff of the entire resolved tree**: exactly **one** third-party change, `java-client` 3.8.3 → 3.11.2. Nothing else moves — no accidental knock-on from the reordering.
- `spring-data-couchbase` 5.5.13 is happy on SDK 3.11.2.
- `mvn clean install -DskipITs` — full reactor **BUILD SUCCESS**, **1700 tests**, zero failures or errors.

## Note

No CVE is involved — this is a correctness/compatibility fix, found while cross-checking a consuming app's dependency remediation list against what synapse actually resolves.